### PR TITLE
Feat: support edit the component/trait/workflow properties via the code

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/icon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=0"/>
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"

--- a/src/components/DefinitionCode/index.tsx
+++ b/src/components/DefinitionCode/index.tsx
@@ -9,9 +9,9 @@ type Props = {
   language: string;
   fileUrl?: string;
   runtime?: any;
-  'data-meta'?: string;
   id?: string;
   onChange?: (params: any) => void;
+  onBlurEditor?: (value: string) => void;
   style?: React.CSSProperties;
 };
 
@@ -25,6 +25,7 @@ class DefinitionCode extends React.Component<Props> {
       language,
       readOnly,
       onChange,
+      onBlurEditor,
       fileUrl = `//b.txt`,
     } = this.props;
     const container: any = document.getElementById(containerId);
@@ -55,6 +56,12 @@ class DefinitionCode extends React.Component<Props> {
       if (onChange) {
         this.editor.onDidChangeModelContent(() => onChange(textModel.getValue()));
       }
+      if (onBlurEditor) {
+        this.editor.onDidBlurEditorText(() => {
+          onBlurEditor(textModel.getValue());
+        });
+      }
+
       monaco.editor.setModelLanguage(textModel, language);
     }
   }

--- a/src/components/ListTitle/index.less
+++ b/src/components/ListTitle/index.less
@@ -1,4 +1,4 @@
-.title-wraper {
+.title-wrapper {
   height: 45px;
   .title {
     font-weight: 500;
@@ -14,7 +14,7 @@
 }
 
 @media (max-width: 719px) and (min-width: 480px) {
-  .title-wraper {
+  .title-wrapper {
     .subTitle {
       display: none;
     }

--- a/src/components/ListTitle/index.tsx
+++ b/src/components/ListTitle/index.tsx
@@ -17,8 +17,8 @@ export default function (props: Props) {
 
   return (
     <div>
-      <Row className="title-wraper">
-        <Col span="15">
+      <Row className="title-wrapper" wrap={true}>
+        <Col xl={15} xs={24}>
           <span className="title font-size-20">
             <Translation>{title}</Translation>
           </span>
@@ -26,7 +26,7 @@ export default function (props: Props) {
             <Translation>{subTitle}</Translation>
           </span>
         </Col>
-        <Col span="9">
+        <Col xl={9} xs={24}>
           <div className="float-right">
             {extButtons &&
               extButtons.map((item) => {

--- a/src/interface/application.ts
+++ b/src/interface/application.ts
@@ -41,7 +41,11 @@ export interface ApplicationBase {
 }
 
 export interface DefinitionDetail {
+  name: string;
+  description: string;
   uiSchema: UIParam[];
+  labels: Record<string, string>;
+  status: string;
 }
 
 export interface UIParam {

--- a/src/layout/index.less
+++ b/src/layout/index.less
@@ -77,8 +77,8 @@
   background-color: #f7f7f7;
 }
 
-@media screen and (max-width: 768px) {
+@media (max-width: 980px) {
   .layout-navigation {
-    min-width: 180px;
+    width: 180px;
   }
 }

--- a/src/pages/ApplicationConfig/components/ComponentDialog/index.tsx
+++ b/src/pages/ApplicationConfig/components/ComponentDialog/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Grid, Field, Form, Message, Button, Input, Select, Divider } from '@b-design/ui';
+import { Grid, Field, Form, Message, Button, Input, Select, Divider, Icon } from '@b-design/ui';
 import type { Rule } from '@alifd/field';
 import { withTranslation } from 'react-i18next';
 import {
@@ -50,6 +50,7 @@ type State = {
   isUpdateComponentLoading: boolean;
   editComponent?: ApplicationComponent;
   loading: boolean;
+  propertiesMode: string;
 };
 
 @connect()
@@ -63,6 +64,7 @@ class ComponentDialog extends React.Component<Props, State> {
       isCreateComponentLoading: false,
       isUpdateComponentLoading: false,
       loading: true,
+      propertiesMode: 'native',
     };
     this.uiSchemaRef = React.createRef();
   }
@@ -336,7 +338,7 @@ class ComponentDialog extends React.Component<Props, State> {
     const FormItem = Form.Item;
     const { Row, Col } = Grid;
     const { isEditComponent, componentDefinitions, onComponentClose } = this.props;
-    const { definitionDetail, loading } = this.state;
+    const { definitionDetail, loading, propertiesMode } = this.state;
     const validator = (rule: Rule, value: any, callback: (error?: string) => void) => {
       this.uiSchemaRef.current?.validate(callback);
     };
@@ -487,10 +489,43 @@ class ComponentDialog extends React.Component<Props, State> {
             </Row>
           </Group>
           <section className="title">
-            <Title title={i18n.t('Deployment Properties')} actions={[]} />
+            <Title
+              title={i18n.t('Deployment Properties')}
+              actions={
+                definitionDetail && definitionDetail.uiSchema
+                  ? [
+                      <Button
+                        style={{ marginTop: '-12px' }}
+                        onClick={() => {
+                          if (propertiesMode === 'native') {
+                            this.setState({ propertiesMode: 'code' });
+                          } else {
+                            this.setState({ propertiesMode: 'native' });
+                          }
+                        }}
+                      >
+                        <If condition={propertiesMode === 'native'}>
+                          <Icon
+                            style={{ color: '#1b58f4' }}
+                            type={'display-code'}
+                            title={'Switch to code mode'}
+                          />
+                        </If>
+                        <If condition={propertiesMode === 'code'}>
+                          <Icon
+                            style={{ color: '#1b58f4' }}
+                            type={'laptop'}
+                            title={'Switch to native mode'}
+                          />
+                        </If>
+                      </Button>,
+                    ]
+                  : []
+              }
+            />
           </section>
           <Row>
-            <If condition={definitionDetail && definitionDetail.uiSchema}>
+            <If condition={definitionDetail}>
               <UISchema
                 {...init(`properties`, {
                   rules: [
@@ -500,7 +535,13 @@ class ComponentDialog extends React.Component<Props, State> {
                     },
                   ],
                 })}
+                enableCodeEdit={propertiesMode === 'code'}
                 uiSchema={definitionDetail && definitionDetail.uiSchema}
+                definition={{
+                  name: definitionDetail?.name || '',
+                  type: 'component',
+                  description: definitionDetail?.description || '',
+                }}
                 ref={this.uiSchemaRef}
                 mode={isEditComponent ? 'edit' : 'new'}
               />

--- a/src/pages/ApplicationConfig/components/TraitDialog/index.tsx
+++ b/src/pages/ApplicationConfig/components/TraitDialog/index.tsx
@@ -47,6 +47,7 @@ type State = {
   traitDefinitions?: DefinitionBase[];
   podDisruptive?: any;
   component?: ApplicationComponent;
+  propertiesMode: 'native' | 'code';
 };
 @connect()
 class TraitDialog extends React.Component<Props, State> {
@@ -58,6 +59,7 @@ class TraitDialog extends React.Component<Props, State> {
       definitionLoading: false,
       isLoading: false,
       traitDefinitions: [],
+      propertiesMode: 'native',
     };
     this.field = new Field(this);
     this.uiSchemaRef = React.createRef();
@@ -286,7 +288,7 @@ class TraitDialog extends React.Component<Props, State> {
     const FormItem = Form.Item;
     const { Row, Col } = Grid;
     const { onClose, isEditTrait } = this.props;
-    const { definitionDetail, definitionLoading, podDisruptive } = this.state;
+    const { definitionDetail, definitionLoading, podDisruptive, propertiesMode } = this.state;
     const validator = (rule: Rule, value: any, callback: (error?: string) => void) => {
       this.uiSchemaRef.current?.validate(callback);
     };
@@ -393,8 +395,37 @@ class TraitDialog extends React.Component<Props, State> {
                 required={true}
                 hasToggleIcon={true}
               >
-                <If condition={definitionDetail && definitionDetail.uiSchema}>
+                <If condition={definitionDetail}>
                   <FormItem required={true}>
+                    <If condition={definitionDetail && definitionDetail.uiSchema}>
+                      <div className="flexright">
+                        <Button
+                          style={{ marginTop: '-12px' }}
+                          onClick={() => {
+                            if (propertiesMode === 'native') {
+                              this.setState({ propertiesMode: 'code' });
+                            } else {
+                              this.setState({ propertiesMode: 'native' });
+                            }
+                          }}
+                        >
+                          <If condition={propertiesMode === 'native'}>
+                            <Icon
+                              style={{ color: '#1b58f4' }}
+                              type={'display-code'}
+                              title={'Switch to code mode'}
+                            />
+                          </If>
+                          <If condition={propertiesMode === 'code'}>
+                            <Icon
+                              style={{ color: '#1b58f4' }}
+                              type={'laptop'}
+                              title={'Switch to native mode'}
+                            />
+                          </If>
+                        </Button>
+                      </div>
+                    </If>
                     <UISchema
                       key={traitType}
                       {...init(`properties`, {
@@ -405,7 +436,13 @@ class TraitDialog extends React.Component<Props, State> {
                           },
                         ],
                       })}
+                      enableCodeEdit={propertiesMode === 'code'}
                       uiSchema={definitionDetail && definitionDetail.uiSchema}
+                      definition={{
+                        type: 'trait',
+                        name: definitionDetail?.name || '',
+                        description: definitionDetail?.description || '',
+                      }}
                       ref={this.uiSchemaRef}
                       mode={this.props.isEditTrait ? 'edit' : 'new'}
                     />

--- a/src/pages/ApplicationWorkflow/workflow-item/workflow-form.tsx
+++ b/src/pages/ApplicationWorkflow/workflow-item/workflow-form.tsx
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import type { DiagramMakerNode } from 'diagram-maker';
 import type { WorkFlowNodeType } from '../entity';
 
-import { Grid, Field, Form, Select, Input, Message, Button } from '@b-design/ui';
+import { Grid, Field, Form, Select, Input, Message, Button, Icon } from '@b-design/ui';
 import type { Rule } from '@alifd/field';
 import { withTranslation } from 'react-i18next';
 import Group from '../../../extends/Group';
@@ -35,6 +35,7 @@ type Props = {
 type State = {
   definitionDetail?: DefinitionDetail;
   definitionLoading: boolean;
+  propertiesMode: 'native' | 'code';
 };
 
 @connect()
@@ -45,6 +46,7 @@ class WorkflowForm extends Component<Props, State> {
     super(props);
     this.state = {
       definitionLoading: false,
+      propertiesMode: 'native',
     };
     this.field = new Field(this, {
       onChange: (name: string, value: string) => {
@@ -129,7 +131,7 @@ class WorkflowForm extends Component<Props, State> {
     const { Row, Col } = Grid;
     const FormItem = Form.Item;
     const { t, closeDrawer, data, checkStepName } = this.props;
-    const { definitionDetail } = this.state;
+    const { definitionDetail, propertiesMode } = this.state;
     const validator = (rule: Rule, value: any, callback: (error?: string) => void) => {
       this.uiSchemaRef.current?.validate(callback);
     };
@@ -260,8 +262,37 @@ class WorkflowForm extends Component<Props, State> {
                 required={true}
                 hasToggleIcon={true}
               >
-                <If condition={definitionDetail && definitionDetail.uiSchema}>
+                <If condition={definitionDetail}>
                   <FormItem required={true}>
+                    <If condition={definitionDetail && definitionDetail.uiSchema}>
+                      <div className="flexright">
+                        <Button
+                          style={{ marginTop: '-12px' }}
+                          onClick={() => {
+                            if (propertiesMode === 'native') {
+                              this.setState({ propertiesMode: 'code' });
+                            } else {
+                              this.setState({ propertiesMode: 'native' });
+                            }
+                          }}
+                        >
+                          <If condition={propertiesMode === 'native'}>
+                            <Icon
+                              style={{ color: '#1b58f4' }}
+                              type={'display-code'}
+                              title={'Switch to code mode'}
+                            />
+                          </If>
+                          <If condition={propertiesMode === 'code'}>
+                            <Icon
+                              style={{ color: '#1b58f4' }}
+                              type={'laptop'}
+                              title={'Switch to native mode'}
+                            />
+                          </If>
+                        </Button>
+                      </div>
+                    </If>
                     <UISchema
                       {...init(`properties`, {
                         rules: [
@@ -271,7 +302,13 @@ class WorkflowForm extends Component<Props, State> {
                           },
                         ],
                       })}
+                      enableCodeEdit={propertiesMode === 'code'}
                       uiSchema={definitionDetail && definitionDetail.uiSchema}
+                      definition={{
+                        type: 'workflowstep',
+                        name: definitionDetail?.name || '',
+                        description: definitionDetail?.description || '',
+                      }}
                       ref={this.uiSchemaRef}
                       mode={this.props.data ? 'edit' : 'new'}
                     />

--- a/src/pages/EnvPage/components/List/index.less
+++ b/src/pages/EnvPage/components/List/index.less
@@ -1,5 +1,8 @@
-.table-delivery-list {
+.table-env-list {
+  overflow: auto;
   .next-table-cell.last .next-table-cell-wrapper {
     text-align: left;
   }
 }
+
+

--- a/src/pages/EnvPage/components/List/index.tsx
+++ b/src/pages/EnvPage/components/List/index.tsx
@@ -80,14 +80,14 @@ class TableList extends Component<Props> {
           return <span>{v}</span>;
         },
       },
-      // {
-      //   key: 'project',
-      //   title: <Translation>Project</Translation>,
-      //   dataIndex: 'project',
-      //   cell: (v: NameAlias) => {
-      //     return <span>{v.alias || v.name}</span>;
-      //   },
-      // },
+      {
+        key: 'project',
+        title: <Translation>Project</Translation>,
+        dataIndex: 'project',
+        cell: (v: NameAlias) => {
+          return <span>{v.alias || v.name}</span>;
+        },
+      },
       {
         key: 'description',
         title: <Translation>Description</Translation>,
@@ -118,6 +118,7 @@ class TableList extends Component<Props> {
         key: 'operation',
         title: <Translation>Actions</Translation>,
         dataIndex: 'operation',
+        width: '120px',
         cell: (v: string, i: number, record: Env) => {
           return (
             <div>
@@ -171,11 +172,12 @@ class TableList extends Component<Props> {
     const columns = this.getColumns();
     const { list } = this.props;
     return (
-      <div className="table-delivery-list margin-top-20">
+      <div className="table-env-list margin-top-20">
         <Table
           locale={locale().Table}
           className="customTable"
           size="medium"
+          style={{ minWidth: '1200px' }}
           dataSource={list}
           hasBorder={false}
           loading={false}

--- a/src/pages/TargetList/components/List/index.less
+++ b/src/pages/TargetList/components/List/index.less
@@ -1,4 +1,5 @@
 .table-delivery-list {
+  overflow: auto;
   .next-table-cell.last .next-table-cell-wrapper {
     text-align: left;
   }

--- a/src/pages/TargetList/components/List/index.tsx
+++ b/src/pages/TargetList/components/List/index.tsx
@@ -140,6 +140,7 @@ class TableList extends Component<Props> {
           locale={locale().Table}
           className="customTable"
           size="medium"
+          style={{ minWidth: '1200px' }}
           dataSource={list}
           hasBorder={false}
           loading={false}


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>

### Description of your changes

1. If there is no UI schema, default provide the YAML code editor, such as the labels trait.
2. Users could switch the native form to the YAML code editor.

![image](https://user-images.githubusercontent.com/18493394/172984500-8ef394ab-4997-4c15-a827-18d021cb18b0.png)

![image](https://user-images.githubusercontent.com/18493394/172984521-1a2dc19b-91fd-4628-b8ce-a475d4adb622.png)

This feature is very useful and resolves the native UI input constraints.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
