### PR TITLE
Feat: use keyboard navigation, press enter to login

### DIFF
--- a/src/pages/Login/index.less
+++ b/src/pages/Login/index.less
@@ -45,7 +45,7 @@
           }
         }
         .next-form {
-          height: 200px !important;
+          height: 210px !important;
         }
         .next-card-footer {
           display: none;

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -173,7 +173,7 @@ export default class LoginPage extends Component<Props, State> {
                   <h3 className="login-title-description">
                     <Translation>Make shipping applications more enjoyable</Translation>
                   </h3>
-                  <Form onSubmit={this.handleSubmit} {...formItemLayout} field={this.field}>
+                  <Form onSubmitCapture={(e) => {e.preventDefault()}} onSubmit={this.handleSubmit} {...formItemLayout} field={this.field}>
                     <FormItem
                       label={<Translation className="label-title">Username</Translation>}
                       labelAlign="top"
@@ -218,15 +218,15 @@ export default class LoginPage extends Component<Props, State> {
                         })}
                       />
                     </FormItem>
+                    <Button loading={loginLoading} type="primary" htmlType="submit" onClick={this.handleSubmit}>
+                      <Translation>Sign in</Translation>
+                    </Button>
                   </Form>
                   <If condition={loginErrorMessage}>
                     <div className="logo-error-wrapper">
                       <Icon type="warning1" /> <Translation>{loginErrorMessage}</Translation>
                     </div>
                   </If>
-                  <Button loading={loginLoading} type="primary" onClick={this.handleSubmit}>
-                    <Translation>Sign in</Translation>
-                  </Button>
                 </Card>
               </div>
             </If>


### PR DESCRIPTION
Signed-off-by: Charlie Chiang <charlie_c_0129@outlook.com>

### Description of your changes

#### Now we can press `enter` to login!

Previously, the login process is like:
- type: admin
- Tab
- type: password
- **reach for the mouse**
- **move it to `sign in`**
- **click the mouse**

Which works, but I prefer **not** to use the mouse.

Now we are able to:
- type: admin
- Tab
- type: password
- Enter

And we are in!

#### I also corrected the layout a bit. 
Before:
![image](https://user-images.githubusercontent.com/55270174/176676495-389c1334-bef3-409c-ae36-1a878e510286.png)
After:
![image](https://user-images.githubusercontent.com/55270174/176675110-b27f8e14-4e84-4f09-beaf-554ce02a3a7e.png)

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->



I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
