### PR TITLE
Feat: add arm64 image build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,7 @@ jobs:
       with:
         context: ./
         file: ./Dockerfile
+        platforms: linux/amd64,linux/arm64
         push: true
         build-args: |
           GITVERSION=git-${{ steps.vars.outputs.git_revision }}


### PR DESCRIPTION
Signed-off-by: qiaozp <chivalry.pp@gmail.com>

### Description of your changes

This PR add linux/arm64 build for velaux.

We want VelaD to support more platform include linux/arm64 and darwin/arm64(M1 mac). They both need a linux/arm64 version for all images that used by VelaD.


<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
