### PR TITLE
Fix: upgrade Nginx to 1.23 and fix CVE-2022-2068

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV VERSION=${VERSION}
 RUN apk add --no-cache git && yarn install && yarn build
 RUN rm -rf /app/velaux/build/mock
 
-FROM nginx:1.21
+FROM nginx:1.23
 ARG GITVERSION
 COPY --from=builder /app/velaux/build /usr/share/nginx/html
 COPY web.conf /etc/nginx/nginx.conf

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM nginx:1.21
+FROM nginx:1.23
 
 COPY build /usr/share/nginx/html
 COPY web.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>

### Description of your changes

https://github.com/kubevela/velaux/security/code-scanning/16063


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.
