### PR TITLE
Fix: can not show the detail of the first revision

### DIFF
--- a/src/pages/ApplicationRevisionList/components/Detail/index.tsx
+++ b/src/pages/ApplicationRevisionList/components/Detail/index.tsx
@@ -43,7 +43,7 @@ export const ShowRevision = (props: RevisionProps) => {
   React.useEffect(() => {
     loadRevisionDetail(props.appName, props.revision, setDetail);
   }, [props.appName, props.revision]);
-  const containerId = props.revision.version;
+  const containerId = props.revision.version + 'detail';
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Signed-off-by: barnettZQG <barnett.zqg@gmail.com>

### Description of your changes

![image](https://user-images.githubusercontent.com/18493394/187624445-29534da3-9ec2-4b5e-9686-c93ac0c66e4d.png)

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
