### PR TITLE
Feat(#536): Graphically display Component and Trait relationships and status

### DIFF
--- a/src/components/TreeGraph/index.less
+++ b/src/components/TreeGraph/index.less
@@ -59,6 +59,20 @@
         color: #666;
       }
     }
+    .trait {
+      height: 24px;
+      line-height: 24px;
+    }
+    .label-dot {
+      width: 5px;
+      height: 5px;
+      border-radius: 5px;
+      background: #2DC86D;
+      display: inline-block;
+      position: absolute;
+      bottom: 7px;
+      left: -9px;
+    }
     .additional {
       position: absolute;
       right: 8px;

--- a/src/components/TreeGraph/index.tsx
+++ b/src/components/TreeGraph/index.tsx
@@ -10,6 +10,7 @@ import {
   nodeKey,
   describeNode,
   describeCluster,
+  describeComponents,
   treeNodeKey,
   getGraphSize,
   getNodeSize,
@@ -29,6 +30,7 @@ type TreeGraphProps = {
   zoom: number;
   appName: string;
   envName: string;
+  graphType: any;
   onNodeClick: (nodeKey: string) => void;
   onResourceDetailClick: (resource: ResourceTreeNode) => void;
 };
@@ -58,294 +60,409 @@ export interface TreeNode {
   leafNodes?: TreeNode[];
 }
 
-function renderResourceNode(props: TreeGraphProps, id: string, node: GraphNode) {
-  const fullName = nodeKey(node);
-  const graphNode = (
-    <div
-      key={id}
-      onClick={() => props.onNodeClick && props.onNodeClick(fullName)}
-      className={classNames('graph-node', 'graph-node-resource', {
-        'error-status': node.resource.healthStatus?.statusCode == 'UnHealthy',
-        'warning-status': node.resource.healthStatus?.statusCode == 'Progressing',
-      })}
-      style={{
-        left: node.x,
-        top: node.y,
-        width: node.width,
-        height: node.height,
-        transform: `translate(-80px, 0px)`,
-      }}
-    >
-      <div className={classNames('icon')}>
-        <ResourceIcon kind={node.resource.kind || ''} />
-      </div>
-      <div className={classNames('name')}>
-        <div>{node.resource.name}</div>
-        <div className="kind">{node.resource.kind}</div>
-      </div>
-      <div className={classNames('actions')}>
-        <Dropdown trigger={<Icon type="ellipsis-vertical" />}>
-          <Menu>
-            <Menu.Item onClick={() => props.onResourceDetailClick(node.resource)}>Detail</Menu.Item>
-          </Menu>
-        </Dropdown>
-      </div>
-      <If condition={node.resource.kind === 'Service' && node.resource.additionalInfo?.EIP}>
-        <div className={classNames('additional')}>
-          <Tag size="small" color="orange">
-            EIP: {node.resource.additionalInfo?.EIP}
-          </Tag>
+type State = {
+  traitsShow: boolean
+}
+
+class TreeGraph extends React.Component<TreeGraphProps, State> {
+  constructor(props: TreeGraphProps) {
+    super(props);
+    this.state = {
+      traitsShow: false,
+    };
+  }
+  renderComponentNode(props: TreeGraphProps, id: string, node: GraphNode) {
+    const fullName = nodeKey(node);
+    const traits = node.resource.service.traits
+    const labelTraits = traits ? (traits[0].alias ? traits[0].alias + '(' + traits[0].type + ')' : traits[0].type) : undefined
+    const graphNode = (
+      <div
+        key={id}
+        onClick={() => props.onNodeClick && props.onNodeClick(fullName)}
+        className={classNames('graph-node', 'graph-node-resource', {
+          'warning-status': !node.resource.service.healthy,
+        })}
+        style={{
+          left: node.x,
+          top: node.y,
+          width: node.width,
+          height: node.height,
+          transform: `translate(-80px, 0px)`,
+        }}
+      >
+        <div className={classNames('icon')}>
+          <ResourceIcon kind={node.resource.componentType.substring(0,1).toUpperCase() || ''} />
         </div>
-      </If>
-    </div>
-  );
-  return (
-    <Balloon trigger={graphNode}>
-      <div>
-        {describeNode(node).map((line) => {
-          return <p className="line">{line}</p>;
-        })}
-      </div>
-    </Balloon>
-  );
-}
-
-function renderAppNode(props: TreeGraphProps, id: string, node: GraphNode) {
-  const fullName = nodeKey(node);
-
-  const graphNode = (
-    <div
-      key={id}
-      onClick={() => props.onNodeClick && props.onNodeClick(fullName)}
-      className={classNames('graph-node', 'graph-node-app')}
-      style={{
-        left: node.x,
-        top: node.y,
-        width: node.width,
-        height: node.height,
-        transform: `translate(-60px, 0px)`,
-      }}
-    >
-      <div className={classNames('icon')}>
-        <img src={kubevela} />
-      </div>
-      <div className={classNames('name')}>
-        <span>{node.resource.name}</span>
-      </div>
-      <div className={classNames('actions')}>
-        <Dropdown trigger={<Icon type="ellipsis-vertical" />}>
-          <Menu>
-            <Menu.Item onClick={() => props.onResourceDetailClick(node.resource)}>Detail</Menu.Item>
-          </Menu>
-        </Dropdown>
-      </div>
-    </div>
-  );
-  return (
-    <Balloon trigger={graphNode}>
-      <div>
-        {describeNode(node).map((line) => {
-          return <p className="line">{line}</p>;
-        })}
-      </div>
-    </Balloon>
-  );
-}
-
-function renderPodNode(props: TreeGraphProps, id: string, node: GraphNode) {
-  const fullName = nodeKey(node);
-  const { appName, envName } = props;
-  const graphNode = (
-    <div
-      key={id}
-      onClick={() => props.onNodeClick && props.onNodeClick(fullName)}
-      className={classNames('graph-node', 'graph-node-pod', {
-        'error-status': node.resource.healthStatus?.statusCode == 'UnHealthy',
-        'warning-status': node.resource.healthStatus?.statusCode == 'Progressing',
-      })}
-      style={{
-        left: node.x,
-        top: node.y,
-        width: node.width,
-        height: node.height,
-        transform: `translate(-80px, 0px)`,
-      }}
-    >
-      <div className={classNames('icon')}>
-        <img src={pod} />
-        <span>Pod</span>
-      </div>
-      <div className={classNames('name')}>
-        <Link
-          to={`/applications/${appName}/envbinding/${envName}/instances?pod=${node.resource.name}`}
-        >
-          {node.resource.name}
-        </Link>
-        <div className={classNames('actions')}>
-          <Link
-            to={`/applications/${appName}/envbinding/${envName}/logs?pod=${node.resource.name}`}
-          >
-            <Icon title={i18n.t('Logger')} type="news" />
-          </Link>
+        <div className={classNames('name')}>
+          <div>{node.resource.name}</div>
         </div>
+        <div className={classNames('healthy')}>
+          <div color={node.resource.service.healthy ? 'green' : 'orange'}>
+            <span className={classNames('label-dot')}></span>{node.resource.service.healthy ? 'Healthy' : 'Unhealthy'}
+          </div>
+        </div>
+        <If condition={labelTraits}>
+          <div className={classNames('label-traits')}>
+            <div>{labelTraits}<span onClick={() =>  {this.setState({ traitsShow: !this.state.traitsShow })}}>{' +' + node.resource.service.traits.length}</span></div>
+          </div>
+        </If>
+        <If condition={labelTraits && this.state.traitsShow}>
+          <div style={{top: '20px', position: 'relative'}}>
+            {traits.map((trait: any, index: any) => {
+              const label = trait.alias ? trait.alias + '(' + trait.type + ')' : trait.type;
+              const num = traits.length === 1 ? 0 : Math.trunc(traits.length / 2)
+              const nodeY = num === index ? -24 : (-24 + (index - num) * 30)
+              return (
+                <div
+                  key={index}
+                  id={label}
+                  className={classNames('graph-node')}
+                  style={{
+                    width: '130px',
+                    right: '-168px',
+                    padding: '0 0 0 16px',
+                    top: nodeY + 'px'
+                  }}
+                >
+                  <div className={classNames('trait')}>
+                    <div><span className={classNames('label-dot')} style={{top: '10px', left: '6px'}}></span>{label}</div>
+                  </div>
+                </div>
+              )
+            })}
+            {traits.map((trait: any, index: any) => {
+              const num = traits.length === 1 ? 0 : Math.trunc(traits.length / 2)
+              const nodeY = num === index ? 0 : ((index - num) * 30)
+              const edgeY = ((index - num) * 15)
+              const distance = Math.sqrt(
+                Math.pow(30, 2) + Math.pow(nodeY, 2),
+              );
+              const xmid = num === index || num === index - 1 || num === index + 1 ? 0 : -(Math.abs((num - index) * (15))) + 15
+              const angle = (Math.atan2(nodeY, 30) * 180) / Math.PI - 180;
+              return (
+                <div 
+                  className="graph-edge-line-traits"
+                  key={index}
+                  style={{
+                    width: distance + 'px',
+                    transform: `translate(${xmid}px, 0) rotate(${angle}deg)`,
+                    top: edgeY + 'px',
+                  }}
+                />
+              )
+            })}
+          </div>
+        </If>
       </div>
-      <div className={classNames('actions')}>
-        <Dropdown trigger={<Icon type="ellipsis-vertical" />}>
-          <Menu>
-            <Menu.Item onClick={() => props.onResourceDetailClick(node.resource)}>Detail</Menu.Item>
-          </Menu>
-        </Dropdown>
-      </div>
-      <div className={classNames('additional')}>
-        <Tag size="small" color="orange">
-          Ready: {node.resource.additionalInfo?.Ready}
-        </Tag>
-      </div>
-    </div>
-  );
-  return (
-    <Balloon trigger={graphNode}>
-      <div>
-        {describeNode(node).map((line) => {
-          return <p className="line">{line}</p>;
-        })}
-      </div>
-    </Balloon>
-  );
-}
-
-function renderClusterNode(props: TreeGraphProps, id: string, node: GraphNode) {
-  const fullName = nodeKey(node);
-
-  const graphNode = (
-    <div
-      onClick={() => props.onNodeClick && props.onNodeClick(fullName)}
-      className={classNames('graph-node', 'graph-node-cluster')}
-      style={{
-        left: node.x,
-        top: node.y,
-        width: node.width,
-        height: node.height,
-        transform: `translate(-40px, 0px)`,
-      }}
-    >
-      <div className="icon">
-        <img src={kubernetes} />
-      </div>
-      <div className={classNames('name')}>
-        <div>{node.resource.name}</div>
-        <div className="kind">Cluster</div>
-      </div>
-    </div>
-  );
-  return (
-    <Balloon trigger={graphNode}>
-      <div>
-        {describeCluster(node).map((line) => {
-          return <p className="line">{line}</p>;
-        })}
-      </div>
-    </Balloon>
-  );
-}
-
-function setNode(graph: dagre.graphlib.Graph<GraphNode, GraphEdge>, node: TreeNode) {
-  const size = getNodeSize(node);
-  graph.setNode(treeNodeKey(node), { ...node, width: size.width, height: size.height, x: 0, y: 0 });
-
-  node.leafNodes?.map((subNode) => {
-    if (treeNodeKey(node) == treeNodeKey(subNode)) {
-      return;
-    }
-    graph.setEdge(treeNodeKey(node), treeNodeKey(subNode), {});
-    setNode(graph, subNode);
-  });
-}
-
-export const TreeGraph = (props: TreeGraphProps) => {
-  // init the graph
-  const graph = new dagre.graphlib.Graph<GraphNode, GraphEdge>();
-  graph.setGraph({ nodesep: 50, rankdir: 'LR' });
-
-  // set node and make layout
-  setNode(graph, props.node);
-  dagre.layout(graph);
-
-  const edges: { from: string; to: string; lines: Line[] }[] = [];
-  graph.edges().forEach((edgeInfo) => {
-    const edge = graph.edge(edgeInfo);
-    const lines: Line[] = [];
-    if (edge.points && edge.points.length > 1) {
-      for (let i = 1; i < edge.points.length; i++) {
-        lines.push({
-          x1: edge.points[i - 1].x,
-          y1: edge.points[i - 1].y,
-          x2: edge.points[i].x,
-          y2: edge.points[i].y,
-        });
-      }
-    }
-    edges.push({
-      from: edgeInfo.v,
-      to: edgeInfo.w,
-      lines: lines,
-    });
-  });
-
-  const graphNodes = graph.nodes();
-
-  const size = getGraphSize(graphNodes.map((id) => graph.node(id)));
-  return (
-    <div
-      className="graph-tree"
-      style={{
-        width: size.width + 300,
-        height: size.height + 150,
-        transformOrigin: '0% 0%',
-        transform: `scale(${props.zoom})`,
-      }}
-    >
-      {graphNodes.map((key) => {
-        const node = graph.node(key);
-        const nodeType = node.nodeType;
-        switch (nodeType) {
-          case 'app':
-            return <React.Fragment key={key}>{renderAppNode(props, key, node)}</React.Fragment>;
-          case 'cluster':
-            return <React.Fragment key={key}>{renderClusterNode(props, key, node)}</React.Fragment>;
-          case 'pod':
-            return <React.Fragment key={key}>{renderPodNode(props, key, node)}</React.Fragment>;
-          default:
-            return (
-              <React.Fragment key={key}>{renderResourceNode(props, key, node)}</React.Fragment>
-            );
-        }
-      })}
-
-      {edges.map((edge) => (
-        <div key={`${edge.from}-${edge.to}`} className="graph-edge">
-          {edge.lines.map((line, i) => {
-            const distance = Math.sqrt(
-              Math.pow(line.x1 - line.x2, 2) + Math.pow(line.y1 - line.y2, 2),
-            );
-            const xMid = (line.x1 + line.x2) / 2;
-            const yMid = (line.y1 + line.y2) / 2;
-            const angle = (Math.atan2(line.y1 - line.y2, line.x1 - line.x2) * 180) / Math.PI;
-            return (
-              <div
-                className="graph-edge-line"
-                key={i}
-                style={{
-                  width: distance,
-                  left: xMid - distance / 2,
-                  top: yMid,
-                  transform: `translate(40px, 30px) rotate(${angle}deg)`,
-                }}
-              />
-            );
+    );
+    return (
+      <Balloon trigger={graphNode}>
+        <div>
+          {describeComponents(node).map((line: any) => {
+            return <p className="line">{line}</p>;
           })}
         </div>
-      ))}
-    </div>
-  );
-};
+      </Balloon>
+    );
+  }
+
+  renderResourceNode(props: TreeGraphProps, id: string, node: GraphNode) {
+    const fullName = nodeKey(node);
+    const graphNode = (
+      <div
+        key={id}
+        onClick={() => props.onNodeClick && props.onNodeClick(fullName)}
+        className={classNames('graph-node', 'graph-node-resource', {
+          'error-status': node.resource.healthStatus?.statusCode == 'UnHealthy',
+          'warning-status': node.resource.healthStatus?.statusCode == 'Progressing',
+        })}
+        style={{
+          left: node.x,
+          top: node.y,
+          width: node.width,
+          height: node.height,
+          transform: `translate(-80px, 0px)`,
+        }}
+      >
+        <div className={classNames('icon')}>
+          <ResourceIcon kind={node.resource.kind || ''} />
+        </div>
+        <div className={classNames('name')}>
+          <div>{node.resource.name}</div>
+          <div className="kind">{node.resource.kind}</div>
+        </div>
+        <div className={classNames('actions')}>
+          <Dropdown trigger={<Icon type="ellipsis-vertical" />}>
+            <Menu>
+              <Menu.Item onClick={() => props.onResourceDetailClick(node.resource)}>Detail</Menu.Item>
+            </Menu>
+          </Dropdown>
+        </div>
+        <If condition={node.resource.kind === 'Service' && node.resource.additionalInfo?.EIP}>
+          <div className={classNames('additional')}>
+            <Tag size="small" color="orange">
+              EIP: {node.resource.additionalInfo?.EIP}
+            </Tag>
+          </div>
+        </If>
+      </div>
+    );
+    return (
+      <Balloon trigger={graphNode}>
+        <div>
+          {describeNode(node).map((line) => {
+            return <p className="line">{line}</p>;
+          })}
+        </div>
+      </Balloon>
+    );
+  }
+  
+  renderAppNode(props: TreeGraphProps, id: string, node: GraphNode) {
+    const fullName = nodeKey(node);
+  
+    const graphNode = (
+      <div
+        key={id}
+        onClick={() => props.onNodeClick && props.onNodeClick(fullName)}
+        className={classNames('graph-node', 'graph-node-app')}
+        style={{
+          left: node.x,
+          top: node.y,
+          width: node.width,
+          height: node.height,
+          transform: `translate(-60px, 0px)`,
+        }}
+      >
+        <div className={classNames('icon')}>
+          <img src={kubevela} />
+        </div>
+        <div className={classNames('name')}>
+          <span>{node.resource.name}</span>
+        </div>
+        <div className={classNames('actions')}>
+          <Dropdown trigger={<Icon type="ellipsis-vertical" />}>
+            <Menu>
+              <Menu.Item onClick={() => props.onResourceDetailClick(node.resource)}>Detail</Menu.Item>
+            </Menu>
+          </Dropdown>
+        </div>
+      </div>
+    );
+    return (
+      <Balloon trigger={graphNode}>
+        <div>
+          {describeNode(node).map((line) => {
+            return <p className="line">{line}</p>;
+          })}
+        </div>
+      </Balloon>
+    );
+  }
+  
+  renderPodNode(props: TreeGraphProps, id: string, node: GraphNode) {
+    const fullName = nodeKey(node);
+    const { appName, envName } = props;
+    const graphNode = (
+      <div
+        key={id}
+        onClick={() => props.onNodeClick && props.onNodeClick(fullName)}
+        className={classNames('graph-node', 'graph-node-pod', {
+          'error-status': node.resource.healthStatus?.statusCode == 'UnHealthy',
+          'warning-status': node.resource.healthStatus?.statusCode == 'Progressing',
+        })}
+        style={{
+          left: node.x,
+          top: node.y,
+          width: node.width,
+          height: node.height,
+          transform: `translate(-80px, 0px)`,
+        }}
+      >
+        <div className={classNames('icon')}>
+          <img src={pod} />
+          <span>Pod</span>
+        </div>
+        <div className={classNames('name')}>
+          <Link
+            to={`/applications/${appName}/envbinding/${envName}/instances?pod=${node.resource.name}`}
+          >
+            {node.resource.name}
+          </Link>
+          <div className={classNames('actions')}>
+            <Link
+              to={`/applications/${appName}/envbinding/${envName}/logs?pod=${node.resource.name}`}
+            >
+              <Icon title={i18n.t('Logger')} type="news" />
+            </Link>
+          </div>
+        </div>
+        <div className={classNames('actions')}>
+          <Dropdown trigger={<Icon type="ellipsis-vertical" />}>
+            <Menu>
+              <Menu.Item onClick={() => props.onResourceDetailClick(node.resource)}>Detail</Menu.Item>
+            </Menu>
+          </Dropdown>
+        </div>
+        <div className={classNames('additional')}>
+          <Tag size="small" color="orange">
+            Ready: {node.resource.additionalInfo?.Ready}
+          </Tag>
+        </div>
+      </div>
+    );
+    return (
+      <Balloon trigger={graphNode}>
+        <div>
+          {describeNode(node).map((line) => {
+            return <p className="line">{line}</p>;
+          })}
+        </div>
+      </Balloon>
+    );
+  }
+  
+  renderClusterNode(props: TreeGraphProps, id: string, node: GraphNode) {
+    const fullName = nodeKey(node);
+  
+    const graphNode = (
+      <div
+        onClick={() => props.onNodeClick && props.onNodeClick(fullName)}
+        className={classNames('graph-node', 'graph-node-cluster')}
+        style={{
+          left: node.x,
+          top: node.y,
+          width: node.width,
+          height: node.height,
+          transform: `translate(-40px, 0px)`,
+        }}
+      >
+        <div className="icon">
+          <img src={kubernetes} />
+        </div>
+        <div className={classNames('name')}>
+          <div>{node.resource.name}</div>
+          <div className="kind">Cluster</div>
+        </div>
+      </div>
+    );
+    return (
+      <Balloon trigger={graphNode}>
+        <div>
+          {describeCluster(node).map((line) => {
+            return <p className="line">{line}</p>;
+          })}
+        </div>
+      </Balloon>
+    );
+  }
+  
+  setNode(graph: dagre.graphlib.Graph<GraphNode, GraphEdge>, node: TreeNode) {
+    const size = getNodeSize(node);
+    graph.setNode(treeNodeKey(node), { ...node, width: size.width, height: size.height, x: 0, y: 0 });
+  
+    node.leafNodes?.map((subNode) => {
+      if (treeNodeKey(node) == treeNodeKey(subNode)) {
+        return;
+      }
+      graph.setEdge(treeNodeKey(node), treeNodeKey(subNode), {});
+      this.setNode(graph, subNode);
+    });
+  }
+
+  render() {
+    // init the graph
+    const { graphType } = this.props
+    const graph = new dagre.graphlib.Graph<GraphNode, GraphEdge>();
+    graph.setGraph({ nodesep: 50, rankdir: graphType === 'resource-graph' ? 'LR' : 'TB'});
+
+    // set node and make layout
+    this.setNode(graph, this.props.node);
+    dagre.layout(graph);
+  
+    const edges: { from: string; to: string; lines: Line[] }[] = [];
+    graph.edges().forEach((edgeInfo) => {
+      const edge = graph.edge(edgeInfo);
+      const lines: Line[] = [];
+      if (edge.points && edge.points.length > 1) {
+        for (let i = 1; i < edge.points.length; i++) {
+          lines.push({
+            x1: edge.points[i - 1].x,
+            y1: edge.points[i - 1].y,
+            x2: edge.points[i].x,
+            y2: edge.points[i].y,
+          });
+        }
+      }
+      edges.push({
+        from: edgeInfo.v,
+        to: edgeInfo.w,
+        lines: lines,
+      });
+    });
+  
+    const graphNodes = graph.nodes();
+  
+    const size = getGraphSize(graphNodes.map((id) => graph.node(id)));
+    return (
+      <div
+        className="graph-tree"
+        style={{
+          width: size.width + 300,
+          height: size.height + 150,
+          transformOrigin: '0% 0%',
+          transform: `scale(${this.props.zoom})`,
+        }}
+      >
+        {graphNodes.map((key) => {
+          const node = graph.node(key);
+          const nodeType = node.nodeType;
+          switch (nodeType) {
+            case 'app':
+              return <React.Fragment key={key}>{this.renderAppNode(this.props, key, node)}</React.Fragment>;
+            case 'cluster':
+              return <React.Fragment key={key}>{this.renderClusterNode(this.props, key, node)}</React.Fragment>;
+            case 'pod':
+              return <React.Fragment key={key}>{this.renderPodNode(this.props, key, node)}</React.Fragment>;
+            case 'component':
+              return <React.Fragment key={key}>{this.renderComponentNode(this.props, key, node)}</React.Fragment>;
+            default:
+              return (
+                <React.Fragment key={key}>{this.renderResourceNode(this.props, key, node)}</React.Fragment>
+              );
+          }
+        })}
+  
+        {edges.map((edge) => (
+          <div key={`${edge.from}-${edge.to}`} className="graph-edge">
+            {edge.lines.map((line, i) => {
+              const distance = Math.sqrt(
+                Math.pow(line.x1 - line.x2, 2) + Math.pow(line.y1 - line.y2, 2),
+              );
+              const xMid = (line.x1 + line.x2) / 2;
+              const yMid = (line.y1 + line.y2) / 2;
+              const angle = (Math.atan2(line.y1 - line.y2, line.x1 - line.x2) * 180) / Math.PI;
+              return (
+                <div
+                  className="graph-edge-line"
+                  key={i}
+                  style={{
+                    width: distance,
+                    left: xMid - distance / 2,
+                    top: yMid,
+                    transform: `translate(40px, 30px) rotate(${angle}deg)`,
+                  }}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    );
+  };
+}
+
+export default TreeGraph;
+
+
+

--- a/src/components/TreeGraph/utils.tsx
+++ b/src/components/TreeGraph/utils.tsx
@@ -66,6 +66,18 @@ export function describeCluster(node: GraphNode) {
   return lines;
 }
 
+export function describeComponents(node: GraphNode) {
+  const lines = [
+    `Name: ${node.resource.name}`,
+    `Namespace: ${node.resource.service.namespace || '(global)'}`,
+    `Cluster: ${node.resource.service.cluster || 'local'}`
+  ];
+  if (node.resource.service.message) {
+    lines.push(`Message: ${node.resource.service.message}`);
+  }
+  return lines;
+}
+
 export function treeNodeKey(node: TreeNode & { uid?: string }) {
   if (node.uid && node.uid.length > 0) {
     return node.uid;

--- a/src/interface/application.ts
+++ b/src/interface/application.ts
@@ -127,6 +127,8 @@ export interface ComponentStatus {
     healthy: string;
     message: string;
   }[];
+  leafNodes?: any;
+  cluster?: string;
 }
 
 export interface Condition {
@@ -212,6 +214,9 @@ export interface ApplicationComponent extends ApplicationComponentBase {
       type: string;
     };
   };
+  kind?: string;
+  service?: ComponentStatus;
+  leafNodes?: any;
 }
 
 export interface ApplicationRevision {

--- a/src/interface/observation.ts
+++ b/src/interface/observation.ts
@@ -222,6 +222,8 @@ export interface ResourceTreeNode extends Resource {
   healthStatus?: ResourceHealthStatus;
   additionalInfo?: Record<string, any>;
   leafNodes?: ResourceTreeNode[];
+  service?: any;
+  componentType?: any
 }
 
 export interface ResourceHealthStatus {

--- a/src/locals/Zh/zh.json
+++ b/src/locals/Zh/zh.json
@@ -553,6 +553,7 @@
   "Please select a workflow": "请选择一个工作流",
   "Please select a payloadType": "请选择请求体类型，不同的外部系统请求参数类型具有差异",
   "Resource Graph": "资源拓扑图",
+  "Application Graph": "应用拓扑图",
   "The ImagePullSecrets property has been automatically assigned": "发现镜像仓库配置，已自动为 ImagePullSecrets 字段赋值",
   "CloudShell feature is not enabled": "云终端功能未启用",
   "You must enable the CloudShell addon": "你需要先启动 CloudShell 插件",


### PR DESCRIPTION
status

Signed-off-by: weiy730 <weiy730@163.com>

### Description of your changes

Feat(https://github.com/kubevela/velaux/issues/536): Graphically display Component and Trait relationships and status

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer
