### PR TITLE
Feat: support to guide the chart configuration from the OCI registry

### DIFF
--- a/src/api/repository.ts
+++ b/src/api/repository.ts
@@ -19,6 +19,25 @@ export function getChartValues(params: {
   }).then((res) => res);
 }
 
+export function getChartValueFiles(params: {
+  url: string;
+  repoType: string;
+  secretName?: string;
+  chart: string;
+  version: string;
+}) {
+  const url = baseURL + repository + '/chart/values';
+  return get(url, {
+    params: {
+      repoUrl: params.url,
+      repoType: params.repoType,
+      secretName: params.secretName,
+      chart: params.chart,
+      version: params.version,
+    },
+  }).then((res) => res);
+}
+
 export function getCharts(params: { url: string; repoType: string; secretName?: string }) {
   const url = baseURL + repository + '/charts';
   return get(url, {
@@ -32,9 +51,14 @@ export function getChartVersions(params: {
   chart: string;
   secretName?: string;
 }) {
-  const url = baseURL + repository + '/charts/' + params.chart + '/versions';
+  const url = baseURL + repository + '/chart/versions';
   return get(url, {
-    params: { repoUrl: params.url, repoType: params.repoType, secretName: params.secretName },
+    params: {
+      repoUrl: params.url,
+      repoType: params.repoType,
+      secretName: params.secretName,
+      chart: params.chart,
+    },
   }).then((res) => res);
 }
 

--- a/src/components/HelmValueShow/index.less
+++ b/src/components/HelmValueShow/index.less
@@ -1,0 +1,5 @@
+.helmValueDialog {
+  .next-dialog-body {
+    padding: 0 !important;
+  }
+}

--- a/src/components/HelmValueShow/index.tsx
+++ b/src/components/HelmValueShow/index.tsx
@@ -1,0 +1,42 @@
+import { Dialog, Select } from '@b-design/ui';
+import * as React from 'react';
+import i18n from '../../i18n';
+import DefinitionCode from '../DefinitionCode';
+import './index.less';
+
+type Props = {
+  onClose: () => void;
+  valueFiles: Record<string, string>;
+  name: string;
+};
+const HelmValueShow: React.FC<Props> = (props: Props) => {
+  const [valueFile, setValueFile] = React.useState<string>('values.yaml');
+  return (
+    <Dialog
+      className={'commonDialog helmValueDialog'}
+      isFullScreen={true}
+      visible={true}
+      onClose={props.onClose}
+      footer={<div />}
+      title={i18n.t('Show Values File')}
+    >
+      <Select
+        onChange={(name) => {
+          setValueFile(name);
+        }}
+        defaultValue={valueFile}
+        dataSource={Object.keys(props.valueFiles)}
+        style={{ marginBottom: '8px' }}
+      />
+      <div id={'chart-' + props.name} className="diff-box">
+        <DefinitionCode
+          language={'yaml'}
+          containerId={'chart-' + props.name}
+          readOnly
+          value={props.valueFiles[valueFile]}
+        />
+      </div>
+    </Dialog>
+  );
+};
+export default HelmValueShow;

--- a/src/interface/repository.ts
+++ b/src/interface/repository.ts
@@ -1,6 +1,6 @@
 export interface HelmRepo {
   url: string;
-  type: string;
+  type?: string;
   secretName?: string;
 }
 

--- a/src/lib.less
+++ b/src/lib.less
@@ -1,5 +1,5 @@
 :root {
-  --min-layout-width: 1400px;
+  --min-layout-width: 1500px;
   --primary-color: #1b58f4;
   --warning-color: var(--message-warning-color-icon-inline, #fac800);
   --hover-color: #f7bca9;

--- a/src/locals/Zh/zh.json
+++ b/src/locals/Zh/zh.json
@@ -616,5 +616,6 @@
   "Clone Pipeline": "克隆流水线",
   "Includes": "包括",
   "contexts": "上下文参数",
-  "Are you sure to rerun this Pipeline?": "确定要重新运行流水线吗？"
+  "Are you sure to rerun this Pipeline?": "确定要重新运行流水线吗？",
+  "Show Values File": "查看 Value 文件"
 }

--- a/src/pages/ApplicationConfig/index.tsx
+++ b/src/pages/ApplicationConfig/index.tsx
@@ -489,7 +489,7 @@ class ApplicationConfig extends Component<Props, State> {
     return (
       <div>
         <Row className="flex-row" wrap={true}>
-          <Col xl={16} m={24} s={24} style={{ padding: '0 8px' }}>
+          <Col xl={16} l={24} s={24} style={{ padding: '0 8px' }}>
             <Card
               locale={locale().Card}
               contentHeight="auto"
@@ -533,7 +533,7 @@ class ApplicationConfig extends Component<Props, State> {
                   </div>
                 </Col>
 
-                <Col l={8} xxs={24}>
+                <Col l={8} xs={24}>
                   <Item
                     label={<Translation>Project</Translation>}
                     value={
@@ -546,7 +546,7 @@ class ApplicationConfig extends Component<Props, State> {
                   />
                 </Col>
 
-                <Col l={8} xxs={24}>
+                <Col l={8} xs={24}>
                   <Item
                     label={<Translation>Create Time</Translation>}
                     value={
@@ -563,7 +563,7 @@ class ApplicationConfig extends Component<Props, State> {
                   />
                 </Col>
 
-                <Col l={8} xxs={24}>
+                <Col l={8} xs={24}>
                   <Item
                     label={<Translation>Update Time</Translation>}
                     value={
@@ -597,7 +597,7 @@ class ApplicationConfig extends Component<Props, State> {
               </Row>
             </Card>
           </Col>
-          <Col xl={8} m={24} s={24} style={{ padding: '0 8px' }}>
+          <Col xl={8} l={24} s={24} style={{ padding: '0 8px' }}>
             <Card locale={locale().Card} contentHeight="auto" style={{ height: '100%' }}>
               <Row>
                 <Col span={6} style={{ padding: '22px 0' }}>
@@ -632,7 +632,7 @@ class ApplicationConfig extends Component<Props, State> {
         </Row>
 
         <Row wrap={true} className="app-spec">
-          <Col xl={8} xs={24} className="app-spec-item">
+          <Col xl={8} xxs={24} className="app-spec-item">
             <Row>
               <Col span={24} className="padding16">
                 <Title
@@ -683,7 +683,7 @@ class ApplicationConfig extends Component<Props, State> {
               changeTraitStats={this.changeTraitStats}
             />
           </Col>
-          <Col xl={8} xs={24} className="app-spec-item">
+          <Col xl={8} xxs={24} className="app-spec-item">
             <Row>
               <Col span={24} className="padding16">
                 <Title
@@ -724,7 +724,7 @@ class ApplicationConfig extends Component<Props, State> {
               }}
             />
           </Col>
-          <Col xl={8} xs={24} className="app-spec-item">
+          <Col xl={8} xxs={24} className="app-spec-item">
             <Row>
               <Col span={24} className="padding16">
                 <Title


### PR DESCRIPTION
### Description of your changes

![image](https://user-images.githubusercontent.com/18493394/218979218-d8a51f08-c90a-4b45-83eb-e18f8c17b9b1.png)

![image](https://user-images.githubusercontent.com/18493394/218979363-aa3fc83d-c884-4b81-9d5f-c214e8187202.png)


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

/cc @wangyikewxgm 
