### PR TITLE
Fix: Add the processing of rollback status to the version list

### DIFF
--- a/packages/velaux-ui/src/pages/ApplicationRevisionList/constants.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationRevisionList/constants.tsx
@@ -4,4 +4,5 @@ export const statusList = [
   { label: 'Complete', value: 'complete' },
   { label: 'Failure', value: 'failure' },
   { label: 'Terminated', value: 'terminated' },
+  { label: 'Rollback', value: 'rollback' },
 ];


### PR DESCRIPTION
### Description of your changes

Fixes #
Add the processing of rollback status to the version list

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer
I don't know whether this rollback state needs a corresponding dot style. If so, what color should it be？I think light blue is good