### PR TITLE
Feat: support get secret from project config for helm chart

### DIFF
--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -4024,7 +4024,8 @@
 						"enum": [
 							"component",
 							"trait",
-							"workflowstep"
+							"workflowstep",
+							"policy"
 						],
 						"type": "string",
 						"description": "query the definition type",
@@ -6809,6 +6810,13 @@
 				"parameters": [
 					{
 						"type": "string",
+						"description": "the config project",
+						"name": "project",
+						"in": "query",
+						"required": true
+					},
+					{
+						"type": "string",
 						"description": "helm chart",
 						"name": "chart",
 						"in": "query",
@@ -6875,6 +6883,13 @@
 				"summary": "list versions",
 				"operationId": "listVersionsFromQuery",
 				"parameters": [
+					{
+						"type": "string",
+						"description": "the config project",
+						"name": "project",
+						"in": "query",
+						"required": true
+					},
 					{
 						"type": "string",
 						"description": "helm chart",
@@ -6975,6 +6990,13 @@
 				"parameters": [
 					{
 						"type": "string",
+						"description": "the config project",
+						"name": "project",
+						"in": "query",
+						"required": true
+					},
+					{
+						"type": "string",
 						"description": "helm repository url",
 						"name": "repoUrl",
 						"in": "query"
@@ -7023,6 +7045,13 @@
 				"operationId": "listChartVersions",
 				"deprecated": true,
 				"parameters": [
+					{
+						"type": "string",
+						"description": "the config project",
+						"name": "project",
+						"in": "query",
+						"required": true
+					},
 					{
 						"type": "string",
 						"description": "identifier of the helm chart",
@@ -7077,6 +7106,13 @@
 				"operationId": "getChartValues",
 				"deprecated": true,
 				"parameters": [
+					{
+						"type": "string",
+						"description": "the config project",
+						"name": "project",
+						"in": "query",
+						"required": true
+					},
 					{
 						"type": "string",
 						"description": "identifier of the helm chart",
@@ -9632,12 +9668,12 @@
 		},
 		"model.WorkflowStep": {
 			"required": [
-				"name",
+				"orderIndex",
 				"alias",
-				"dependsOn",
 				"type",
 				"description",
-				"orderIndex"
+				"dependsOn",
+				"name"
 			],
 			"properties": {
 				"alias": {
@@ -9754,9 +9790,9 @@
 		},
 		"model.WorkflowStepStatus": {
 			"required": [
+				"id",
 				"name",
-				"alias",
-				"id"
+				"alias"
 			],
 			"properties": {
 				"alias": {
@@ -10339,13 +10375,13 @@
 		},
 		"v1.ApplicationDeployResponse": {
 			"required": [
+				"status",
+				"createTime",
+				"version",
+				"note",
 				"envName",
 				"triggerType",
 				"workflowName",
-				"status",
-				"note",
-				"createTime",
-				"version",
 				"record"
 			],
 			"properties": {
@@ -12050,13 +12086,13 @@
 		},
 		"v1.DetailApplicationResponse": {
 			"required": [
-				"project",
 				"description",
-				"icon",
-				"name",
-				"alias",
 				"createTime",
 				"updateTime",
+				"icon",
+				"alias",
+				"project",
+				"name",
 				"policies",
 				"envBindings",
 				"resourceInfo"
@@ -12113,20 +12149,20 @@
 		},
 		"v1.DetailClusterResponse": {
 			"required": [
-				"createTime",
 				"apiServerURL",
 				"dashboardURL",
-				"kubeConfig",
-				"kubeConfigSecret",
-				"updateTime",
-				"name",
-				"alias",
-				"description",
-				"icon",
 				"labels",
+				"name",
+				"updateTime",
+				"alias",
 				"status",
+				"createTime",
+				"icon",
 				"reason",
 				"provider",
+				"kubeConfig",
+				"kubeConfigSecret",
+				"description",
 				"resourceInfo"
 			],
 			"properties": {
@@ -12184,14 +12220,14 @@
 		},
 		"v1.DetailComponentResponse": {
 			"required": [
+				"updateTime",
+				"name",
+				"creator",
+				"alias",
 				"type",
 				"createTime",
-				"main",
 				"appPrimaryKey",
-				"creator",
-				"name",
-				"updateTime",
-				"alias",
+				"main",
 				"definition"
 			],
 			"properties": {
@@ -12279,13 +12315,13 @@
 		},
 		"v1.DetailDefinitionResponse": {
 			"required": [
-				"description",
-				"icon",
-				"ownerAddon",
+				"labels",
 				"name",
 				"alias",
 				"status",
-				"labels",
+				"ownerAddon",
+				"description",
+				"icon",
 				"schema",
 				"uiSchema"
 			],
@@ -12342,15 +12378,15 @@
 		},
 		"v1.DetailPolicyResponse": {
 			"required": [
-				"description",
-				"creator",
-				"createTime",
+				"properties",
 				"updateTime",
+				"envName",
 				"name",
 				"alias",
 				"type",
-				"properties",
-				"envName"
+				"description",
+				"creator",
+				"createTime"
 			],
 			"properties": {
 				"alias": {
@@ -12392,18 +12428,18 @@
 		},
 		"v1.DetailRevisionResponse": {
 			"required": [
-				"reason",
+				"status",
 				"deployUser",
-				"triggerType",
-				"envName",
-				"updateTime",
+				"appPrimaryKey",
 				"version",
 				"revisionCRName",
-				"status",
 				"note",
-				"workflowName",
+				"envName",
 				"createTime",
-				"appPrimaryKey"
+				"reason",
+				"triggerType",
+				"workflowName",
+				"updateTime"
 			],
 			"properties": {
 				"appPrimaryKey": {
@@ -12460,10 +12496,10 @@
 		},
 		"v1.DetailTargetResponse": {
 			"required": [
+				"createTime",
 				"updateTime",
 				"project",
-				"name",
-				"createTime"
+				"name"
 			],
 			"properties": {
 				"alias": {
@@ -12503,11 +12539,11 @@
 		},
 		"v1.DetailUserResponse": {
 			"required": [
+				"lastLoginTime",
 				"name",
 				"email",
 				"disabled",
 				"createTime",
-				"lastLoginTime",
 				"projects",
 				"roles"
 			],
@@ -12548,12 +12584,12 @@
 		},
 		"v1.DetailWorkflowRecordResponse": {
 			"required": [
-				"namespace",
-				"mode",
-				"workflowAlias",
 				"status",
 				"message",
+				"mode",
 				"name",
+				"namespace",
+				"workflowAlias",
 				"applicationRevision",
 				"workflowName",
 				"deployTime",
@@ -12617,16 +12653,16 @@
 		},
 		"v1.DetailWorkflowResponse": {
 			"required": [
-				"mode",
-				"subMode",
 				"name",
+				"alias",
+				"description",
+				"default",
+				"subMode",
+				"enable",
 				"envName",
 				"createTime",
 				"updateTime",
-				"alias",
-				"description",
-				"enable",
-				"default"
+				"mode"
 			],
 			"properties": {
 				"alias": {
@@ -12864,9 +12900,9 @@
 				"name",
 				"alias",
 				"project",
+				"spec",
 				"description",
 				"createTime",
-				"spec",
 				"info"
 			],
 			"properties": {
@@ -12909,10 +12945,10 @@
 		},
 		"v1.GetPipelineRunLogResponse": {
 			"required": [
-				"type",
-				"phase",
 				"id",
 				"name",
+				"type",
+				"phase",
 				"source",
 				"log"
 			],
@@ -13566,11 +13602,11 @@
 		},
 		"v1.LoginUserInfoResponse": {
 			"required": [
+				"createTime",
 				"lastLoginTime",
 				"name",
 				"email",
 				"disabled",
-				"createTime",
 				"projects",
 				"platformPermissions",
 				"projectPermissions"
@@ -13772,11 +13808,11 @@
 		},
 		"v1.PipelineBase": {
 			"required": [
+				"description",
+				"createTime",
 				"name",
 				"alias",
 				"project",
-				"description",
-				"createTime",
 				"spec"
 			],
 			"properties": {
@@ -13875,11 +13911,11 @@
 		},
 		"v1.PipelineMetaResponse": {
 			"required": [
+				"project",
 				"description",
 				"createTime",
 				"name",
-				"alias",
-				"project"
+				"alias"
 			],
 			"properties": {
 				"alias": {
@@ -13902,13 +13938,13 @@
 		},
 		"v1.PipelineRun": {
 			"required": [
+				"spec",
 				"project",
 				"pipelineRunName",
+				"pipelineName",
 				"record",
 				"contextName",
 				"contextValues",
-				"spec",
-				"pipelineName",
 				"status"
 			],
 			"properties": {
@@ -13944,9 +13980,9 @@
 		},
 		"v1.PipelineRunBase": {
 			"required": [
-				"pipelineName",
 				"project",
 				"pipelineRunName",
+				"pipelineName",
 				"record",
 				"contextName",
 				"contextValues",
@@ -14419,10 +14455,10 @@
 		},
 		"v1.StepOutputBase": {
 			"required": [
-				"id",
 				"name",
 				"type",
 				"phase",
+				"id",
 				"values"
 			],
 			"properties": {
@@ -14505,9 +14541,9 @@
 		},
 		"v1.SystemInfoResponse": {
 			"required": [
-				"platformID",
 				"enableCollection",
 				"loginType",
+				"platformID",
 				"systemVersion"
 			],
 			"properties": {
@@ -15031,14 +15067,14 @@
 		},
 		"v1.WorkflowRecord": {
 			"required": [
-				"status",
 				"name",
-				"namespace",
-				"applicationRevision",
-				"mode",
 				"workflowName",
+				"status",
+				"message",
+				"mode",
+				"namespace",
 				"workflowAlias",
-				"message"
+				"applicationRevision"
 			],
 			"properties": {
 				"applicationRevision": {

--- a/packages/velaux-ui/src/api/repository.ts
+++ b/packages/velaux-ui/src/api/repository.ts
@@ -26,6 +26,7 @@ export function getChartValueFiles(params: {
   secretName?: string;
   chart: string;
   version: string;
+  project?: string
 }) {
   const url = baseURL + repository + '/chart/values';
   return get(url, {
@@ -35,14 +36,15 @@ export function getChartValueFiles(params: {
       secretName: params.secretName,
       chart: params.chart,
       version: params.version,
+      project: params.project
     },
   }).then((res) => res);
 }
 
-export function getCharts(params: { url: string; repoType: string; secretName?: string }) {
+export function getCharts(params: { url: string; repoType: string; secretName?: string; project?: string }) {
   const url = baseURL + repository + '/charts';
   return get(url, {
-    params: { repoUrl: params.url, repoType: params.repoType, secretName: params.secretName },
+    params: { repoUrl: params.url, repoType: params.repoType, secretName: params.secretName, project: params.project },
   }).then((res) => res);
 }
 
@@ -51,6 +53,7 @@ export function getChartVersions(params: {
   repoType: string;
   chart: string;
   secretName?: string;
+  project?: string
 }) {
   const url = baseURL + repository + '/chart/versions';
   return get(url, {
@@ -59,6 +62,7 @@ export function getChartVersions(params: {
       repoType: params.repoType,
       secretName: params.secretName,
       chart: params.chart,
+      project: params.project
     },
   }).then((res) => res);
 }

--- a/packages/velaux-ui/src/extends/HelmChartSelect/index.tsx
+++ b/packages/velaux-ui/src/extends/HelmChartSelect/index.tsx
@@ -16,6 +16,7 @@ type Props = {
     url: string;
     repoType: string;
   };
+  project?: string;
   repo?: HelmRepo;
 };
 
@@ -44,6 +45,7 @@ class HelmChartSelect extends Component<Props, State> {
   }
 
   loadCharts = () => {
+    const { project } = this.props;
     const { helm, repo } = this.props;
     if (helm?.url && (!this.state.loading || this.state.helm?.url != helm.url)) {
       // Reset chart value
@@ -51,7 +53,7 @@ class HelmChartSelect extends Component<Props, State> {
         this.props.onChange('');
       }
       this.setState({ loading: true, helm: helm });
-      getCharts({ url: helm.url, repoType: helm.repoType, secretName: repo?.secretName }).then(
+      getCharts({ url: helm.url, repoType: helm.repoType, secretName: repo?.secretName, project: project }).then(
         (re: string[]) => {
           this.setState({ charts: re && Array.isArray(re) ? re : [], loading: false, helm: helm });
         },

--- a/packages/velaux-ui/src/extends/HelmChartVersionSelect/index.tsx
+++ b/packages/velaux-ui/src/extends/HelmChartVersionSelect/index.tsx
@@ -17,6 +17,7 @@ type Props = {
     repoType: string;
     chart: string;
   };
+  project?: string;
   repo?: HelmRepo;
 };
 
@@ -46,6 +47,7 @@ class HelmChartVersionSelect extends Component<Props, State> {
   }
 
   loadChartVersions = () => {
+    const { project } = this.props;
     const { helm, repo } = this.props;
     if (
       helm?.url &&
@@ -63,6 +65,7 @@ class HelmChartVersionSelect extends Component<Props, State> {
         repoType: helm.repoType,
         chart: helm.chart,
         secretName: repo?.secretName,
+        project: project
       }).then((re: { versions: ChartVersion[] }) => {
         if (re) {
           this.setState({ versions: re.versions || [], loading: false, helm: helm });

--- a/packages/velaux-ui/src/extends/HelmValues/index.tsx
+++ b/packages/velaux-ui/src/extends/HelmValues/index.tsx
@@ -26,6 +26,7 @@ type Props = {
     chart: string;
     version: string;
   };
+  project?: string;
   repo?: HelmRepo;
 };
 
@@ -85,9 +86,10 @@ class HelmValues extends Component<Props, State> {
   }
 
   loadChartValues = () => {
+    const { project } = this.props;
     const { helm, repo } = this.props;
     if (helm?.chart && helm.version && helm.url) {
-      getChartValueFiles({ ...helm, secretName: repo?.secretName }).then(
+      getChartValueFiles({ ...helm, secretName: repo?.secretName, project: project }).then(
         (re: Record<string, string>) => {
           if (re) {
             try {

--- a/pkg/server/domain/service/helm.go
+++ b/pkg/server/domain/service/helm.go
@@ -83,6 +83,9 @@ func (d defaultHelmImpl) ListChartNames(ctx context.Context, repoURL string, sec
 	var err error
 	if len(secretName) != 0 {
 		opts, err = d.GetHelmHTTPOption(ctx, secretName, projectName)
+		if err != nil {
+			return nil, err
+		}
 	}
 	charts, err := d.helper.ListChartsFromRepo(repoURL, skipCache, opts)
 	if err != nil {
@@ -100,6 +103,9 @@ func (d defaultHelmImpl) ListChartVersions(ctx context.Context, repoURL string, 
 	var err error
 	if len(secretName) != 0 {
 		opts, err = d.GetHelmHTTPOption(ctx, secretName, projectName)
+		if err != nil {
+			return nil, err
+		}
 	}
 	chartVersions, err := d.helper.ListVersions(repoURL, chartName, skipCache, opts)
 	if err != nil {
@@ -121,6 +127,9 @@ func (d defaultHelmImpl) ListChartValuesFiles(ctx context.Context, repoURL strin
 	var err error
 	if len(secretName) != 0 {
 		opts, err = d.GetHelmHTTPOption(ctx, secretName, projectName)
+		if err != nil {
+			return nil, err
+		}
 	}
 	v, err := d.helper.GetValuesFromChart(repoURL, chartName, version, skipCache, repoType, opts)
 	if err != nil {
@@ -138,6 +147,9 @@ func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, cha
 	var err error
 	if len(secretName) != 0 {
 		opts, err = d.GetHelmHTTPOption(ctx, secretName, projectName)
+		if err != nil {
+			return nil, err
+		}
 	}
 	v, err := d.helper.GetValuesFromChart(repoURL, chartName, version, skipCache, repoType, opts)
 	if err != nil {

--- a/pkg/server/domain/service/helm.go
+++ b/pkg/server/domain/service/helm.go
@@ -66,6 +66,9 @@ func (d defaultHelmImpl) GetHelmHTTPOption(ctx context.Context, secretName strin
 			return nil, bcode.ErrRepoBasicAuth
 		}
 		opts, err = helm.SetHTTPOption(ctx, d.K8sClient, types2.NamespacedName{Namespace: config.Namespace, Name: secretName})
+		if err != nil {
+			return nil, bcode.ErrRepoBasicAuth
+		}
 	} else {
 		opts, err = helm.SetHTTPOption(ctx, d.K8sClient, types2.NamespacedName{Namespace: types.DefaultKubeVelaNS, Name: secretName})
 		if err != nil {

--- a/pkg/server/domain/service/helm.go
+++ b/pkg/server/domain/service/helm.go
@@ -44,11 +44,11 @@ func NewHelmService() HelmService {
 
 // HelmService responsible handle helm related interface
 type HelmService interface {
-	ListChartNames(ctx context.Context, url string, secretName string, skipCache bool) ([]string, error)
-	ListChartVersions(ctx context.Context, url string, chartName string, secretName string, skipCache bool) (repo.ChartVersions, error)
-	ListChartValuesFiles(ctx context.Context, url string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]string, error)
+	ListChartNames(ctx context.Context, url string, secretName string, projectName string, skipCache bool) ([]string, error)
+	ListChartVersions(ctx context.Context, url string, chartName string, secretName string, projectName string, skipCache bool) (repo.ChartVersions, error)
+	ListChartValuesFiles(ctx context.Context, url string, chartName string, version string, secretName string, projectName string, repoType string, skipCache bool) (map[string]string, error)
 	ListChartRepo(ctx context.Context, projectName string) (*v1.ChartRepoResponseList, error)
-	GetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]interface{}, error)
+	GetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, projectName string, repoType string, skipCache bool) (map[string]interface{}, error)
 }
 
 type defaultHelmImpl struct {
@@ -57,17 +57,32 @@ type defaultHelmImpl struct {
 	ConfigService ConfigService `inject:""`
 }
 
-func (d defaultHelmImpl) ListChartNames(ctx context.Context, repoURL string, secretName string, skipCache bool) ([]string, error) {
+func (d defaultHelmImpl) GetHelmHTTPOption(ctx context.Context, secretName string, project string) (*common.HTTPOption, error) {
+	var opts *common.HTTPOption
+	var err error
+	if project != "" {
+		config, err := d.ConfigService.GetConfig(ctx, project, secretName)
+		if err != nil {
+			return nil, bcode.ErrRepoBasicAuth
+		}
+		opts, err = helm.SetHTTPOption(ctx, d.K8sClient, types2.NamespacedName{Namespace: config.Namespace, Name: secretName})
+	} else {
+		opts, err = helm.SetHTTPOption(ctx, d.K8sClient, types2.NamespacedName{Namespace: types.DefaultKubeVelaNS, Name: secretName})
+		if err != nil {
+			return nil, bcode.ErrRepoBasicAuth
+		}
+	}
+	return opts, nil
+}
+
+func (d defaultHelmImpl) ListChartNames(ctx context.Context, repoURL string, secretName string, projectName string, skipCache bool) ([]string, error) {
 	if !utils.IsValidURL(repoURL) {
 		return nil, bcode.ErrRepoInvalidURL
 	}
 	var opts *common.HTTPOption
 	var err error
 	if len(secretName) != 0 {
-		opts, err = helm.SetHTTPOption(ctx, d.K8sClient, types2.NamespacedName{Namespace: types.DefaultKubeVelaNS, Name: secretName})
-		if err != nil {
-			return nil, bcode.ErrRepoBasicAuth
-		}
+		opts, err = d.GetHelmHTTPOption(ctx, secretName, projectName)
 	}
 	charts, err := d.helper.ListChartsFromRepo(repoURL, skipCache, opts)
 	if err != nil {
@@ -77,17 +92,14 @@ func (d defaultHelmImpl) ListChartNames(ctx context.Context, repoURL string, sec
 	return charts, nil
 }
 
-func (d defaultHelmImpl) ListChartVersions(ctx context.Context, repoURL string, chartName string, secretName string, skipCache bool) (repo.ChartVersions, error) {
+func (d defaultHelmImpl) ListChartVersions(ctx context.Context, repoURL string, chartName string, secretName string, projectName string, skipCache bool) (repo.ChartVersions, error) {
 	if !utils.IsValidURL(repoURL) {
 		return nil, bcode.ErrRepoInvalidURL
 	}
 	var opts *common.HTTPOption
 	var err error
 	if len(secretName) != 0 {
-		opts, err = helm.SetHTTPOption(ctx, d.K8sClient, types2.NamespacedName{Namespace: types.DefaultKubeVelaNS, Name: secretName})
-		if err != nil {
-			return nil, bcode.ErrRepoBasicAuth
-		}
+		opts, err = d.GetHelmHTTPOption(ctx, secretName, projectName)
 	}
 	chartVersions, err := d.helper.ListVersions(repoURL, chartName, skipCache, opts)
 	if err != nil {
@@ -101,17 +113,14 @@ func (d defaultHelmImpl) ListChartVersions(ctx context.Context, repoURL string, 
 	return chartVersions, nil
 }
 
-func (d defaultHelmImpl) ListChartValuesFiles(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]string, error) {
+func (d defaultHelmImpl) ListChartValuesFiles(ctx context.Context, repoURL string, chartName string, version string, secretName string, projectName string, repoType string, skipCache bool) (map[string]string, error) {
 	if !utils.IsValidURL(repoURL) {
 		return nil, bcode.ErrRepoInvalidURL
 	}
 	var opts *common.HTTPOption
 	var err error
 	if len(secretName) != 0 {
-		opts, err = helm.SetHTTPOption(ctx, d.K8sClient, types2.NamespacedName{Namespace: types.DefaultKubeVelaNS, Name: secretName})
-		if err != nil {
-			return nil, bcode.ErrRepoBasicAuth
-		}
+		opts, err = d.GetHelmHTTPOption(ctx, secretName, projectName)
 	}
 	v, err := d.helper.GetValuesFromChart(repoURL, chartName, version, skipCache, repoType, opts)
 	if err != nil {
@@ -121,17 +130,14 @@ func (d defaultHelmImpl) ListChartValuesFiles(ctx context.Context, repoURL strin
 	return v.Data, nil
 }
 
-func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, repoType string, skipCache bool) (map[string]interface{}, error) {
+func (d defaultHelmImpl) GetChartValues(ctx context.Context, repoURL string, chartName string, version string, secretName string, projectName string, repoType string, skipCache bool) (map[string]interface{}, error) {
 	if !utils.IsValidURL(repoURL) {
 		return nil, bcode.ErrRepoInvalidURL
 	}
 	var opts *common.HTTPOption
 	var err error
 	if len(secretName) != 0 {
-		opts, err = helm.SetHTTPOption(ctx, d.K8sClient, types2.NamespacedName{Namespace: types.DefaultKubeVelaNS, Name: secretName})
-		if err != nil {
-			return nil, bcode.ErrRepoBasicAuth
-		}
+		opts, err = d.GetHelmHTTPOption(ctx, secretName, projectName)
 	}
 	v, err := d.helper.GetValuesFromChart(repoURL, chartName, version, skipCache, repoType, opts)
 	if err != nil {

--- a/pkg/server/domain/service/helm_test.go
+++ b/pkg/server/domain/service/helm_test.go
@@ -204,17 +204,17 @@ var _ = Describe("test helm usecasae", func() {
 
 		u, _, err := NewTestHelmService()
 		Expect(err).Should(BeNil())
-		charts, err := u.ListChartNames(ctx, mockServer.URL, "repo-secret", false)
+		charts, err := u.ListChartNames(ctx, mockServer.URL, "repo-secret", "", false)
 		Expect(err).Should(BeNil())
 		Expect(len(charts)).Should(BeEquivalentTo(1))
 		Expect(charts[0]).Should(BeEquivalentTo("mysql"))
 
-		versions, err := u.ListChartVersions(ctx, mockServer.URL, "mysql", "repo-secret", false)
+		versions, err := u.ListChartVersions(ctx, mockServer.URL, "mysql", "repo-secret", "", false)
 		Expect(err).Should(BeNil())
 		Expect(len(versions)).Should(BeEquivalentTo(1))
 		Expect(versions[0].Version).Should(BeEquivalentTo("8.8.23"))
 
-		values, err := u.ListChartValuesFiles(ctx, mockServer.URL, "mysql", "8.8.23", "repo-secret", "helm", false)
+		values, err := u.ListChartValuesFiles(ctx, mockServer.URL, "mysql", "8.8.23", "repo-secret", "", "helm", false)
 		Expect(err).Should(BeNil())
 		Expect(values).ShouldNot(BeNil())
 		Expect(len(values)).ShouldNot(BeEquivalentTo(0))
@@ -223,13 +223,13 @@ var _ = Describe("test helm usecasae", func() {
 	It("coverage not secret notExist error", func() {
 		u, _, err := NewTestHelmService()
 		Expect(err).Should(BeNil())
-		_, err = u.ListChartNames(ctx, "http://127.0.0.1:8080", "repo-secret-notExist", false)
+		_, err = u.ListChartNames(ctx, "http://127.0.0.1:8080", "repo-secret-notExist", "", false)
 		Expect(err).ShouldNot(BeNil())
 
-		_, err = u.ListChartVersions(ctx, "http://127.0.0.1:8080", "mysql", "repo-secret-notExist", false)
+		_, err = u.ListChartVersions(ctx, "http://127.0.0.1:8080", "mysql", "repo-secret-notExist", "", false)
 		Expect(err).ShouldNot(BeNil())
 
-		_, err = u.ListChartValuesFiles(ctx, "http://127.0.0.1:8080", "mysql", "8.8.23", "repo-secret-notExist", "helm", false)
+		_, err = u.ListChartValuesFiles(ctx, "http://127.0.0.1:8080", "mysql", "8.8.23", "repo-secret-notExist", "", "helm", false)
 		Expect(err).ShouldNot(BeNil())
 	})
 })


### PR DESCRIPTION
### Description of your changes

Support get secret from project config for helm chart.


![im](https://user-images.githubusercontent.com/107997570/224940135-68a972f3-7564-4908-b47f-77abf55228cf.png)


![im](https://user-images.githubusercontent.com/107997570/224940232-36cbd232-a398-42f6-b1c0-f05856ff54e9.png)

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
