### PR TITLE
Fix: make API Server OpenAPI compliant

### DIFF
--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -234,13 +234,6 @@
 				"parameters": [
 					{
 						"type": "string",
-						"description": "addon name to query detail",
-						"name": "name",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
 						"description": "specify addon version to enable",
 						"name": "version",
 						"in": "query"
@@ -4029,9 +4022,9 @@
 				"parameters": [
 					{
 						"enum": [
-							"",
-							"",
-							""
+							"component",
+							"trait",
+							"workflowstep"
 						],
 						"type": "string",
 						"description": "query the definition type",
@@ -4138,6 +4131,13 @@
 				"operationId": "updateDefinitionStatus",
 				"parameters": [
 					{
+						"type": "string",
+						"description": "identifier of the definition",
+						"name": "definitionName",
+						"in": "path",
+						"required": true
+					},
+					{
 						"name": "body",
 						"in": "body",
 						"required": true,
@@ -4175,6 +4175,13 @@
 				"summary": "Update the UI schema for a definition",
 				"operationId": "updateUISchema",
 				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the definition",
+						"name": "definitionName",
+						"in": "path",
+						"required": true
+					},
 					{
 						"name": "body",
 						"in": "body",
@@ -4780,8 +4787,15 @@
 					"project"
 				],
 				"summary": "Detail a template",
-				"operationId": "getConfigTemplate",
+				"operationId": "getConfigTemplateByTemplateName",
 				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the project",
+						"name": "projectName",
+						"in": "path",
+						"required": true
+					},
 					{
 						"type": "string",
 						"description": "identifier of the config template",
@@ -4826,7 +4840,7 @@
 					"project"
 				],
 				"summary": "get configs which are in a project",
-				"operationId": "getConfigs",
+				"operationId": "getProjectConfigs",
 				"parameters": [
 					{
 						"type": "string",
@@ -4870,7 +4884,7 @@
 					"project"
 				],
 				"summary": "create a config in a project",
-				"operationId": "createConfig",
+				"operationId": "createProjectConfig",
 				"parameters": [
 					{
 						"type": "string",
@@ -4971,7 +4985,7 @@
 					"project"
 				],
 				"summary": "update a config in a project",
-				"operationId": "updateConfig",
+				"operationId": "updateProjectConfig",
 				"parameters": [
 					{
 						"type": "string",
@@ -5024,7 +5038,7 @@
 					"project"
 				],
 				"summary": "delete a config from a project",
-				"operationId": "deleteConfig",
+				"operationId": "deleteProjectConfig",
 				"parameters": [
 					{
 						"type": "string",
@@ -7011,6 +7025,13 @@
 				"parameters": [
 					{
 						"type": "string",
+						"description": "identifier of the helm chart",
+						"name": "chart",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
 						"description": "helm repository url",
 						"name": "repoUrl",
 						"in": "query"
@@ -7056,6 +7077,20 @@
 				"operationId": "getChartValues",
 				"deprecated": true,
 				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the helm chart",
+						"name": "chart",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "version of the helm chart",
+						"name": "version",
+						"in": "path",
+						"required": true
+					},
 					{
 						"type": "string",
 						"description": "helm repository url",
@@ -7702,6 +7737,15 @@
 				],
 				"summary": "get user detail",
 				"operationId": "detailUser",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of a user",
+						"name": "username",
+						"in": "path",
+						"required": true
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -7732,6 +7776,13 @@
 				"summary": "update a user's alias or password",
 				"operationId": "updateUser",
 				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of a user",
+						"name": "username",
+						"in": "path",
+						"required": true
+					},
 					{
 						"name": "body",
 						"in": "body",
@@ -7770,6 +7821,15 @@
 				],
 				"summary": "delete a user",
 				"operationId": "deleteUser",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of a user",
+						"name": "username",
+						"in": "path",
+						"required": true
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -7801,6 +7861,15 @@
 				],
 				"summary": "disable a user",
 				"operationId": "disableUser",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of a user",
+						"name": "username",
+						"in": "path",
+						"required": true
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -7832,6 +7901,15 @@
 				],
 				"summary": "enable a user",
 				"operationId": "enableUser",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of a user",
+						"name": "username",
+						"in": "path",
+						"required": true
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -8071,7 +8149,17 @@
 					"cloudshell"
 				],
 				"summary": "prepare the user's cloud shell environment",
-				"operationId": "proxy",
+				"operationId": "proxyPath",
+				"parameters": [
+					{
+						"pattern": "*",
+						"type": "string",
+						"description": "subpath",
+						"name": "subpath",
+						"in": "path",
+						"required": true
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -9544,9 +9632,9 @@
 		},
 		"model.WorkflowStep": {
 			"required": [
-				"dependsOn",
 				"name",
 				"alias",
+				"dependsOn",
 				"type",
 				"description",
 				"orderIndex"
@@ -10251,12 +10339,13 @@
 		},
 		"v1.ApplicationDeployResponse": {
 			"required": [
-				"version",
-				"note",
-				"triggerType",
 				"envName",
-				"createTime",
+				"triggerType",
+				"workflowName",
 				"status",
+				"note",
+				"createTime",
+				"version",
 				"record"
 			],
 			"properties": {
@@ -10292,6 +10381,9 @@
 					"type": "string"
 				},
 				"version": {
+					"type": "string"
+				},
+				"workflowName": {
 					"type": "string"
 				}
 			}
@@ -10358,7 +10450,8 @@
 				"status",
 				"note",
 				"envName",
-				"triggerType"
+				"triggerType",
+				"workflowName"
 			],
 			"properties": {
 				"codeInfo": {
@@ -10390,6 +10483,9 @@
 					"type": "string"
 				},
 				"version": {
+					"type": "string"
+				},
+				"workflowName": {
 					"type": "string"
 				}
 			}
@@ -11034,13 +11130,13 @@
 		},
 		"v1.ConfigTemplateDetail": {
 			"required": [
-				"namespace",
-				"description",
 				"scope",
 				"sensitive",
 				"createTime",
 				"alias",
 				"name",
+				"namespace",
+				"description",
 				"schema",
 				"uiSchema"
 			],
@@ -11870,11 +11966,11 @@
 		},
 		"v1.DetailAddonResponse": {
 			"required": [
-				"invisible",
 				"name",
 				"version",
 				"description",
 				"icon",
+				"invisible",
 				"schema",
 				"uiSchema",
 				"definitions",
@@ -11954,13 +12050,13 @@
 		},
 		"v1.DetailApplicationResponse": {
 			"required": [
-				"alias",
-				"updateTime",
-				"icon",
-				"name",
 				"project",
 				"description",
+				"icon",
+				"name",
+				"alias",
 				"createTime",
+				"updateTime",
 				"policies",
 				"envBindings",
 				"resourceInfo"
@@ -12017,20 +12113,20 @@
 		},
 		"v1.DetailClusterResponse": {
 			"required": [
-				"description",
-				"labels",
-				"provider",
+				"createTime",
+				"apiServerURL",
+				"dashboardURL",
 				"kubeConfig",
 				"kubeConfigSecret",
 				"updateTime",
-				"apiServerURL",
 				"name",
-				"reason",
 				"alias",
+				"description",
 				"icon",
+				"labels",
 				"status",
-				"dashboardURL",
-				"createTime",
+				"reason",
+				"provider",
 				"resourceInfo"
 			],
 			"properties": {
@@ -12088,14 +12184,14 @@
 		},
 		"v1.DetailComponentResponse": {
 			"required": [
-				"appPrimaryKey",
-				"name",
-				"alias",
+				"type",
 				"createTime",
 				"main",
+				"appPrimaryKey",
 				"creator",
-				"type",
+				"name",
 				"updateTime",
+				"alias",
 				"definition"
 			],
 			"properties": {
@@ -12183,12 +12279,12 @@
 		},
 		"v1.DetailDefinitionResponse": {
 			"required": [
-				"status",
-				"name",
-				"alias",
+				"description",
 				"icon",
 				"ownerAddon",
-				"description",
+				"name",
+				"alias",
+				"status",
 				"labels",
 				"schema",
 				"uiSchema"
@@ -12246,15 +12342,15 @@
 		},
 		"v1.DetailPolicyResponse": {
 			"required": [
-				"updateTime",
-				"envName",
-				"alias",
-				"type",
+				"description",
 				"creator",
 				"createTime",
+				"updateTime",
 				"name",
-				"description",
-				"properties"
+				"alias",
+				"type",
+				"properties",
+				"envName"
 			],
 			"properties": {
 				"alias": {
@@ -12296,18 +12392,18 @@
 		},
 		"v1.DetailRevisionResponse": {
 			"required": [
-				"createTime",
-				"revisionCRName",
-				"workflowName",
-				"updateTime",
-				"status",
-				"note",
-				"triggerType",
-				"appPrimaryKey",
 				"reason",
 				"deployUser",
+				"triggerType",
 				"envName",
-				"version"
+				"updateTime",
+				"version",
+				"revisionCRName",
+				"status",
+				"note",
+				"workflowName",
+				"createTime",
+				"appPrimaryKey"
 			],
 			"properties": {
 				"appPrimaryKey": {
@@ -12364,10 +12460,10 @@
 		},
 		"v1.DetailTargetResponse": {
 			"required": [
-				"createTime",
-				"project",
 				"updateTime",
-				"name"
+				"project",
+				"name",
+				"createTime"
 			],
 			"properties": {
 				"alias": {
@@ -12407,11 +12503,11 @@
 		},
 		"v1.DetailUserResponse": {
 			"required": [
-				"createTime",
-				"lastLoginTime",
 				"name",
 				"email",
 				"disabled",
+				"createTime",
+				"lastLoginTime",
 				"projects",
 				"roles"
 			],
@@ -12452,14 +12548,14 @@
 		},
 		"v1.DetailWorkflowRecordResponse": {
 			"required": [
+				"namespace",
+				"mode",
 				"workflowAlias",
 				"status",
-				"workflowName",
-				"mode",
-				"namespace",
-				"name",
 				"message",
+				"name",
 				"applicationRevision",
+				"workflowName",
 				"deployTime",
 				"deployUser",
 				"note",
@@ -12521,16 +12617,16 @@
 		},
 		"v1.DetailWorkflowResponse": {
 			"required": [
-				"name",
-				"default",
-				"createTime",
-				"envName",
-				"updateTime",
 				"mode",
 				"subMode",
+				"name",
+				"envName",
+				"createTime",
+				"updateTime",
 				"alias",
 				"description",
-				"enable"
+				"enable",
+				"default"
 			],
 			"properties": {
 				"alias": {
@@ -12765,12 +12861,12 @@
 		},
 		"v1.GetPipelineResponse": {
 			"required": [
-				"spec",
 				"name",
 				"alias",
 				"project",
 				"description",
 				"createTime",
+				"spec",
 				"info"
 			],
 			"properties": {
@@ -12813,10 +12909,10 @@
 		},
 		"v1.GetPipelineRunLogResponse": {
 			"required": [
+				"type",
 				"phase",
 				"id",
 				"name",
-				"type",
 				"source",
 				"log"
 			],
@@ -13470,11 +13566,11 @@
 		},
 		"v1.LoginUserInfoResponse": {
 			"required": [
-				"createTime",
 				"lastLoginTime",
 				"name",
 				"email",
 				"disabled",
+				"createTime",
 				"projects",
 				"platformPermissions",
 				"projectPermissions"
@@ -13721,11 +13817,11 @@
 		},
 		"v1.PipelineListItem": {
 			"required": [
+				"createTime",
+				"name",
 				"alias",
 				"project",
 				"description",
-				"createTime",
-				"name",
 				"info"
 			],
 			"properties": {
@@ -14294,10 +14390,10 @@
 		},
 		"v1.StepInputBase": {
 			"required": [
-				"phase",
 				"id",
 				"name",
 				"type",
+				"phase",
 				"values"
 			],
 			"properties": {
@@ -14323,10 +14419,10 @@
 		},
 		"v1.StepOutputBase": {
 			"required": [
-				"phase",
 				"id",
 				"name",
 				"type",
+				"phase",
 				"values"
 			],
 			"properties": {
@@ -14935,14 +15031,14 @@
 		},
 		"v1.WorkflowRecord": {
 			"required": [
-				"message",
-				"mode",
-				"namespace",
-				"workflowAlias",
-				"applicationRevision",
 				"status",
 				"name",
-				"workflowName"
+				"namespace",
+				"applicationRevision",
+				"mode",
+				"workflowName",
+				"workflowAlias",
+				"message"
 			],
 			"properties": {
 				"applicationRevision": {

--- a/pkg/server/interfaces/api/addon.go
+++ b/pkg/server/interfaces/api/addon.go
@@ -73,7 +73,6 @@ func (s *addon) GetWebServiceRoute() *restful.WebService {
 		Filter(s.RbacService.CheckPerm("addon", "detail")).
 		Returns(200, "OK", apis.DetailAddonResponse{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
-		Param(ws.PathParameter("name", "addon name to query detail").DataType("string").Required(true)).
 		Param(ws.QueryParameter("version", "specify addon version to enable").DataType("string").Required(false)).
 		Param(ws.PathParameter("addonName", "addon name to query detail").DataType("string").Required(true)).
 		Param(ws.QueryParameter("registry", "filter addons from given registry").DataType("string")).

--- a/pkg/server/interfaces/api/cloudshell.go
+++ b/pkg/server/interfaces/api/cloudshell.go
@@ -135,6 +135,8 @@ func (c *CloudShellView) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.GET("/{subpath:*}").To(c.proxy).
 		Doc("prepare the user's cloud shell environment").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Operation("proxyPath").
+		Param(ws.PathParameter("subpath", "subpath").DataType("string")).
 		Filter(c.RbacService.CheckPerm("cloudshell", "create")).
 		Returns(200, "OK", apis.EmptyResponse{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).

--- a/pkg/server/interfaces/api/definition.go
+++ b/pkg/server/interfaces/api/definition.go
@@ -48,7 +48,7 @@ func (d *definition) GetWebServiceRoute() *restful.WebService {
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		// TODO: provide project scope api for query definition list
 		// Filter(d.RbacService.CheckPerm("definition", "list")).
-		Param(ws.QueryParameter("type", "query the definition type").DataType("string").Required(true).AllowableValues(map[string]string{"component": "", "trait": "", "workflowstep": ""})).
+		Param(ws.QueryParameter("type", "query the definition type").DataType("string").Required(true).PossibleValues([]string{"component", "trait", "workflowstep", "policy"})).
 		Param(ws.QueryParameter("queryAll", "query all definitions include hidden in UI").DataType("boolean").DefaultValue("false")).
 		Param(ws.QueryParameter("appliedWorkload", "if specified, query the trait definition applied to the workload").DataType("string")).
 		Param(ws.QueryParameter("ownerAddon", "query by which addon created the definition").DataType("string")).
@@ -69,6 +69,7 @@ func (d *definition) GetWebServiceRoute() *restful.WebService {
 		Doc("Update the UI schema for a definition").
 		Filter(d.RbacService.CheckPerm("definition", "update")).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.PathParameter("definitionName", "identifier of the definition").DataType("string").Required(true)).
 		Reads(apis.UpdateUISchemaRequest{}).
 		Returns(200, "update successfully", schema.UISchema{}).
 		Writes(apis.DetailDefinitionResponse{}).Do(returns200, returns500))
@@ -77,6 +78,7 @@ func (d *definition) GetWebServiceRoute() *restful.WebService {
 		Doc("Update the status for a definition").
 		Filter(d.RbacService.CheckPerm("definition", "update")).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.PathParameter("definitionName", "identifier of the definition").DataType("string").Required(true)).
 		Reads(apis.UpdateDefinitionStatusRequest{}).
 		Returns(200, "update successfully", schema.UISchema{}).
 		Writes(apis.DetailDefinitionResponse{}).Do(returns200, returns500))

--- a/pkg/server/interfaces/api/project.go
+++ b/pkg/server/interfaces/api/project.go
@@ -213,7 +213,9 @@ func (n *project) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.GET("/{projectName}/config_templates/{templateName}").To(n.getConfigTemplate).
 		Doc("Detail a template").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Operation("getConfigTemplateByTemplateName").
 		Filter(n.RbacService.CheckPerm("project/config", "get")).
+		Param(ws.PathParameter("projectName", "identifier of the project").DataType("string").Required(true)).
 		Param(ws.PathParameter("templateName", "identifier of the config template").DataType("string")).
 		Param(ws.QueryParameter("namespace", "the name of the namespace").DataType("string")).
 		Returns(200, "OK", apis.ConfigTemplateDetail{}).
@@ -223,6 +225,7 @@ func (n *project) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.GET("/{projectName}/configs").To(n.getConfigs).
 		Doc("get configs which are in a project").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Operation("getProjectConfigs").
 		Filter(n.RbacService.CheckPerm("project/config", "list")).
 		Param(ws.QueryParameter("template", "the template name").DataType("string")).
 		Param(ws.PathParameter("projectName", "identifier of the project").DataType("string").Required(true)).
@@ -233,6 +236,7 @@ func (n *project) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.POST("/{projectName}/configs").To(n.createConfig).
 		Doc("create a config in a project").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Operation("createProjectConfig").
 		Filter(n.RbacService.CheckPerm("project/config", "list")).
 		Param(ws.PathParameter("projectName", "identifier of the project").DataType("string").Required(true)).
 		Reads(apis.CreateConfigRequest{}).
@@ -243,6 +247,7 @@ func (n *project) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.DELETE("/{projectName}/configs/{configName}").To(n.deleteConfig).
 		Doc("delete a config from a project").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Operation("deleteProjectConfig").
 		Filter(n.RbacService.CheckPerm("project/config", "list")).
 		Param(ws.PathParameter("projectName", "identifier of the project").DataType("string").Required(true)).
 		Param(ws.PathParameter("configName", "identifier of the config").DataType("string").Required(true)).
@@ -253,6 +258,7 @@ func (n *project) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.PUT("/{projectName}/configs/{configName}").To(n.updateConfig).
 		Doc("update a config in a project").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Operation("updateProjectConfig").
 		Filter(n.RbacService.CheckPerm("project/config", "list")).
 		Param(ws.PathParameter("projectName", "identifier of the project").DataType("string").Required(true)).
 		Param(ws.PathParameter("configName", "identifier of the config").DataType("string").Required(true)).

--- a/pkg/server/interfaces/api/repository.go
+++ b/pkg/server/interfaces/api/repository.go
@@ -83,6 +83,7 @@ func (h repository) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.GET("/charts/{chart}/versions").To(h.listChartVersions).
 		Doc("list versions").Deprecate().
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.PathParameter("chart", "identifier of the helm chart").DataType("string").Required(true)).
 		Param(ws.QueryParameter("repoUrl", "helm repository url").DataType("string")).
 		Param(ws.QueryParameter("secretName", "secret of the repo").DataType("string")).
 		Returns(200, "OK", v1.ChartVersionListResponse{}).
@@ -105,6 +106,8 @@ func (h repository) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.GET("/charts/{chart}/versions/{version}/values").To(h.getChartValues).
 		Doc("get chart value").Deprecate().
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.PathParameter("chart", "identifier of the helm chart").DataType("string").Required(true)).
+		Param(ws.PathParameter("version", "version of the helm chart").DataType("string").Required(true)).
 		Param(ws.QueryParameter("repoUrl", "helm repository url").DataType("string")).
 		Param(ws.QueryParameter("secretName", "secret of the repo").DataType("string")).
 		Returns(200, "OK", map[string]interface{}{}).

--- a/pkg/server/interfaces/api/user.go
+++ b/pkg/server/interfaces/api/user.go
@@ -73,6 +73,7 @@ func (c *user) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.GET("/{username}").To(c.detailUser).
 		Doc("get user detail").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.PathParameter("username", "identifier of a user").DataType("string").Required(true)).
 		Filter(c.RbacService.CheckPerm("user", "detail")).
 		Filter(c.userCheckFilter).
 		Returns(200, "OK", apis.DetailUserResponse{}).
@@ -82,6 +83,7 @@ func (c *user) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.PUT("/{username}").To(c.updateUser).
 		Doc("update a user's alias or password").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.PathParameter("username", "identifier of a user").DataType("string").Required(true)).
 		Filter(c.RbacService.CheckPerm("user", "update")).
 		Filter(c.userCheckFilter).
 		Reads(apis.UpdateUserRequest{}).
@@ -92,6 +94,7 @@ func (c *user) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.DELETE("/{username}").To(c.deleteUser).
 		Doc("delete a user").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.PathParameter("username", "identifier of a user").DataType("string").Required(true)).
 		Filter(c.RbacService.CheckPerm("user", "delete")).
 		Returns(200, "OK", apis.EmptyResponse{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
@@ -100,6 +103,7 @@ func (c *user) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.GET("/{username}/disable").To(c.disableUser).
 		Doc("disable a user").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.PathParameter("username", "identifier of a user").DataType("string").Required(true)).
 		Filter(c.RbacService.CheckPerm("user", "disable")).
 		Filter(c.userCheckFilter).
 		Returns(200, "OK", apis.EmptyResponse{}).
@@ -109,6 +113,7 @@ func (c *user) GetWebServiceRoute() *restful.WebService {
 	ws.Route(ws.GET("/{username}/enable").To(c.enableUser).
 		Doc("enable a user").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.PathParameter("username", "identifier of a user").DataType("string").Required(true)).
 		Filter(c.RbacService.CheckPerm("user", "enable")).
 		Filter(c.userCheckFilter).
 		Returns(200, "OK", apis.EmptyResponse{}).


### PR DESCRIPTION
### Description of your changes

This PR fixes the incompliant swagger specification that is generated by the API Server module. This will let us generate SDKs from the generated swagger.

Validate fix using [openapi generator](https://openapi-generator.tech/):
```bash
openapi-generator generate -i docs/apidoc/swagger.json -g java -o _tmp
```

Or using [swagger-cli](https://apitools.dev/swagger-cli/):
```bash
swagger-cli validate docs/apidoc/swagger.json
```

Fixes kubevela/kubevela#5536

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [x] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

I would be happy to pick up the related task: https://github.com/kubevela/kubevela/issues/5428 as part of GSOC.
