### PR TITLE
Feat: support label filter for application list

### DIFF
--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -8980,8 +8980,8 @@
 		},
 		"config.ClusterTargetStatus": {
 			"required": [
-				"clusterName",
 				"namespace",
+				"clusterName",
 				"status",
 				"application",
 				"message"
@@ -9544,11 +9544,11 @@
 		},
 		"model.WorkflowStep": {
 			"required": [
-				"dependsOn",
 				"name",
+				"description",
+				"dependsOn",
 				"alias",
 				"type",
-				"description",
 				"orderIndex"
 			],
 			"properties": {
@@ -9666,9 +9666,9 @@
 		},
 		"model.WorkflowStepStatus": {
 			"required": [
+				"id",
 				"name",
-				"alias",
-				"id"
+				"alias"
 			],
 			"properties": {
 				"alias": {
@@ -10251,12 +10251,12 @@
 		},
 		"v1.ApplicationDeployResponse": {
 			"required": [
+				"status",
+				"createTime",
 				"version",
 				"note",
-				"triggerType",
 				"envName",
-				"createTime",
-				"status",
+				"triggerType",
 				"record"
 			],
 			"properties": {
@@ -11034,13 +11034,13 @@
 		},
 		"v1.ConfigTemplateDetail": {
 			"required": [
-				"namespace",
-				"description",
-				"scope",
 				"sensitive",
 				"createTime",
 				"alias",
 				"name",
+				"namespace",
+				"description",
+				"scope",
 				"schema",
 				"uiSchema"
 			],
@@ -11870,11 +11870,11 @@
 		},
 		"v1.DetailAddonResponse": {
 			"required": [
-				"invisible",
-				"name",
 				"version",
+				"name",
 				"description",
 				"icon",
+				"invisible",
 				"schema",
 				"uiSchema",
 				"definitions",
@@ -11954,13 +11954,13 @@
 		},
 		"v1.DetailApplicationResponse": {
 			"required": [
-				"alias",
-				"updateTime",
-				"icon",
-				"name",
-				"project",
 				"description",
+				"updateTime",
+				"name",
+				"alias",
+				"project",
 				"createTime",
+				"icon",
 				"policies",
 				"envBindings",
 				"resourceInfo"
@@ -12017,20 +12017,20 @@
 		},
 		"v1.DetailClusterResponse": {
 			"required": [
-				"description",
-				"labels",
+				"name",
+				"alias",
+				"apiServerURL",
+				"createTime",
+				"reason",
 				"provider",
-				"kubeConfig",
 				"kubeConfigSecret",
 				"updateTime",
-				"apiServerURL",
-				"name",
-				"reason",
-				"alias",
+				"description",
+				"labels",
 				"icon",
 				"status",
 				"dashboardURL",
-				"createTime",
+				"kubeConfig",
 				"resourceInfo"
 			],
 			"properties": {
@@ -12088,14 +12088,14 @@
 		},
 		"v1.DetailComponentResponse": {
 			"required": [
-				"appPrimaryKey",
 				"name",
-				"alias",
-				"createTime",
 				"main",
+				"createTime",
+				"alias",
+				"updateTime",
+				"appPrimaryKey",
 				"creator",
 				"type",
-				"updateTime",
 				"definition"
 			],
 			"properties": {
@@ -12184,11 +12184,11 @@
 		"v1.DetailDefinitionResponse": {
 			"required": [
 				"status",
-				"name",
-				"alias",
-				"icon",
 				"ownerAddon",
+				"alias",
 				"description",
+				"icon",
+				"name",
 				"labels",
 				"schema",
 				"uiSchema"
@@ -12246,15 +12246,15 @@
 		},
 		"v1.DetailPolicyResponse": {
 			"required": [
+				"name",
+				"type",
+				"creator",
 				"updateTime",
 				"envName",
 				"alias",
-				"type",
-				"creator",
-				"createTime",
-				"name",
 				"description",
-				"properties"
+				"properties",
+				"createTime"
 			],
 			"properties": {
 				"alias": {
@@ -12296,18 +12296,18 @@
 		},
 		"v1.DetailRevisionResponse": {
 			"required": [
-				"createTime",
+				"triggerType",
 				"revisionCRName",
+				"reason",
+				"status",
+				"envName",
+				"createTime",
+				"version",
 				"workflowName",
 				"updateTime",
-				"status",
-				"note",
-				"triggerType",
 				"appPrimaryKey",
-				"reason",
 				"deployUser",
-				"envName",
-				"version"
+				"note"
 			],
 			"properties": {
 				"appPrimaryKey": {
@@ -12364,10 +12364,10 @@
 		},
 		"v1.DetailTargetResponse": {
 			"required": [
-				"createTime",
 				"project",
-				"updateTime",
-				"name"
+				"name",
+				"createTime",
+				"updateTime"
 			],
 			"properties": {
 				"alias": {
@@ -12407,11 +12407,11 @@
 		},
 		"v1.DetailUserResponse": {
 			"required": [
+				"disabled",
 				"createTime",
 				"lastLoginTime",
 				"name",
 				"email",
-				"disabled",
 				"projects",
 				"roles"
 			],
@@ -12452,14 +12452,14 @@
 		},
 		"v1.DetailWorkflowRecordResponse": {
 			"required": [
-				"workflowAlias",
-				"status",
-				"workflowName",
-				"mode",
-				"namespace",
-				"name",
-				"message",
 				"applicationRevision",
+				"mode",
+				"workflowAlias",
+				"workflowName",
+				"name",
+				"namespace",
+				"status",
+				"message",
 				"deployTime",
 				"deployUser",
 				"note",
@@ -12521,16 +12521,16 @@
 		},
 		"v1.DetailWorkflowResponse": {
 			"required": [
-				"name",
-				"default",
 				"createTime",
-				"envName",
 				"updateTime",
 				"mode",
-				"subMode",
 				"alias",
 				"description",
-				"enable"
+				"envName",
+				"subMode",
+				"name",
+				"enable",
+				"default"
 			],
 			"properties": {
 				"alias": {
@@ -12765,12 +12765,12 @@
 		},
 		"v1.GetPipelineResponse": {
 			"required": [
-				"spec",
-				"name",
-				"alias",
 				"project",
 				"description",
 				"createTime",
+				"spec",
+				"name",
+				"alias",
 				"info"
 			],
 			"properties": {
@@ -12813,10 +12813,10 @@
 		},
 		"v1.GetPipelineRunLogResponse": {
 			"required": [
-				"phase",
 				"id",
 				"name",
 				"type",
+				"phase",
 				"source",
 				"log"
 			],
@@ -13470,11 +13470,11 @@
 		},
 		"v1.LoginUserInfoResponse": {
 			"required": [
-				"createTime",
-				"lastLoginTime",
 				"name",
 				"email",
 				"disabled",
+				"createTime",
+				"lastLoginTime",
 				"projects",
 				"platformPermissions",
 				"projectPermissions"
@@ -13721,11 +13721,11 @@
 		},
 		"v1.PipelineListItem": {
 			"required": [
+				"name",
 				"alias",
 				"project",
 				"description",
 				"createTime",
-				"name",
 				"info"
 			],
 			"properties": {
@@ -13779,11 +13779,11 @@
 		},
 		"v1.PipelineMetaResponse": {
 			"required": [
-				"description",
 				"createTime",
 				"name",
 				"alias",
-				"project"
+				"project",
+				"description"
 			],
 			"properties": {
 				"alias": {
@@ -13806,13 +13806,13 @@
 		},
 		"v1.PipelineRun": {
 			"required": [
-				"project",
-				"pipelineRunName",
-				"record",
-				"contextName",
 				"contextValues",
 				"spec",
+				"pipelineRunName",
 				"pipelineName",
+				"project",
+				"record",
+				"contextName",
 				"status"
 			],
 			"properties": {
@@ -13848,9 +13848,9 @@
 		},
 		"v1.PipelineRunBase": {
 			"required": [
+				"pipelineRunName",
 				"pipelineName",
 				"project",
-				"pipelineRunName",
 				"record",
 				"contextName",
 				"contextValues",
@@ -14294,10 +14294,10 @@
 		},
 		"v1.StepInputBase": {
 			"required": [
-				"phase",
 				"id",
 				"name",
 				"type",
+				"phase",
 				"values"
 			],
 			"properties": {
@@ -14323,10 +14323,10 @@
 		},
 		"v1.StepOutputBase": {
 			"required": [
-				"phase",
 				"id",
 				"name",
 				"type",
+				"phase",
 				"values"
 			],
 			"properties": {
@@ -14409,9 +14409,9 @@
 		},
 		"v1.SystemInfoResponse": {
 			"required": [
-				"platformID",
 				"enableCollection",
 				"loginType",
+				"platformID",
 				"systemVersion"
 			],
 			"properties": {
@@ -14935,14 +14935,14 @@
 		},
 		"v1.WorkflowRecord": {
 			"required": [
-				"message",
+				"workflowName",
+				"applicationRevision",
 				"mode",
+				"name",
 				"namespace",
 				"workflowAlias",
-				"applicationRevision",
 				"status",
-				"name",
-				"workflowName"
+				"message"
 			],
 			"properties": {
 				"applicationRevision": {
@@ -15033,8 +15033,8 @@
 		},
 		"v1.WorkflowStep": {
 			"required": [
-				"name",
-				"type"
+				"type",
+				"name"
 			],
 			"properties": {
 				"alias": {

--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -234,13 +234,6 @@
 				"parameters": [
 					{
 						"type": "string",
-						"description": "addon name to query detail",
-						"name": "name",
-						"in": "path",
-						"required": true
-					},
-					{
-						"type": "string",
 						"description": "specify addon version to enable",
 						"name": "version",
 						"in": "query"
@@ -4029,9 +4022,9 @@
 				"parameters": [
 					{
 						"enum": [
-							"",
-							"",
-							""
+							"component",
+							"trait",
+							"workflowstep"
 						],
 						"type": "string",
 						"description": "query the definition type",
@@ -4138,6 +4131,13 @@
 				"operationId": "updateDefinitionStatus",
 				"parameters": [
 					{
+						"type": "string",
+						"description": "identifier of the definition",
+						"name": "definitionName",
+						"in": "path",
+						"required": true
+					},
+					{
 						"name": "body",
 						"in": "body",
 						"required": true,
@@ -4175,6 +4175,13 @@
 				"summary": "Update the UI schema for a definition",
 				"operationId": "updateUISchema",
 				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the definition",
+						"name": "definitionName",
+						"in": "path",
+						"required": true
+					},
 					{
 						"name": "body",
 						"in": "body",
@@ -4780,8 +4787,15 @@
 					"project"
 				],
 				"summary": "Detail a template",
-				"operationId": "getConfigTemplate",
+				"operationId": "getConfigTemplateByTemplateName",
 				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the project",
+						"name": "projectName",
+						"in": "path",
+						"required": true
+					},
 					{
 						"type": "string",
 						"description": "identifier of the config template",
@@ -4826,7 +4840,7 @@
 					"project"
 				],
 				"summary": "get configs which are in a project",
-				"operationId": "getConfigs",
+				"operationId": "getProjectConfigs",
 				"parameters": [
 					{
 						"type": "string",
@@ -4870,7 +4884,7 @@
 					"project"
 				],
 				"summary": "create a config in a project",
-				"operationId": "createConfig",
+				"operationId": "createProjectConfig",
 				"parameters": [
 					{
 						"type": "string",
@@ -4971,7 +4985,7 @@
 					"project"
 				],
 				"summary": "update a config in a project",
-				"operationId": "updateConfig",
+				"operationId": "updateProjectConfig",
 				"parameters": [
 					{
 						"type": "string",
@@ -5024,7 +5038,7 @@
 					"project"
 				],
 				"summary": "delete a config from a project",
-				"operationId": "deleteConfig",
+				"operationId": "deleteProjectConfig",
 				"parameters": [
 					{
 						"type": "string",
@@ -7011,6 +7025,13 @@
 				"parameters": [
 					{
 						"type": "string",
+						"description": "identifier of the helm chart",
+						"name": "chart",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
 						"description": "helm repository url",
 						"name": "repoUrl",
 						"in": "query"
@@ -7056,6 +7077,20 @@
 				"operationId": "getChartValues",
 				"deprecated": true,
 				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the helm chart",
+						"name": "chart",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "version of the helm chart",
+						"name": "version",
+						"in": "path",
+						"required": true
+					},
 					{
 						"type": "string",
 						"description": "helm repository url",
@@ -7702,6 +7737,15 @@
 				],
 				"summary": "get user detail",
 				"operationId": "detailUser",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of a user",
+						"name": "username",
+						"in": "path",
+						"required": true
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -7732,6 +7776,13 @@
 				"summary": "update a user's alias or password",
 				"operationId": "updateUser",
 				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of a user",
+						"name": "username",
+						"in": "path",
+						"required": true
+					},
 					{
 						"name": "body",
 						"in": "body",
@@ -7770,6 +7821,15 @@
 				],
 				"summary": "delete a user",
 				"operationId": "deleteUser",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of a user",
+						"name": "username",
+						"in": "path",
+						"required": true
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -7801,6 +7861,15 @@
 				],
 				"summary": "disable a user",
 				"operationId": "disableUser",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of a user",
+						"name": "username",
+						"in": "path",
+						"required": true
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -7832,6 +7901,15 @@
 				],
 				"summary": "enable a user",
 				"operationId": "enableUser",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of a user",
+						"name": "username",
+						"in": "path",
+						"required": true
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -8071,7 +8149,17 @@
 					"cloudshell"
 				],
 				"summary": "prepare the user's cloud shell environment",
-				"operationId": "proxy",
+				"operationId": "proxyPath",
+				"parameters": [
+					{
+						"pattern": "*",
+						"type": "string",
+						"description": "subpath",
+						"name": "subpath",
+						"in": "path",
+						"required": true
+					}
+				],
 				"responses": {
 					"200": {
 						"description": "OK",
@@ -8980,8 +9068,8 @@
 		},
 		"config.ClusterTargetStatus": {
 			"required": [
-				"namespace",
 				"clusterName",
+				"namespace",
 				"status",
 				"application",
 				"message"
@@ -9545,10 +9633,10 @@
 		"model.WorkflowStep": {
 			"required": [
 				"name",
-				"description",
-				"dependsOn",
 				"alias",
+				"dependsOn",
 				"type",
+				"description",
 				"orderIndex"
 			],
 			"properties": {
@@ -9666,9 +9754,9 @@
 		},
 		"model.WorkflowStepStatus": {
 			"required": [
-				"id",
 				"name",
-				"alias"
+				"alias",
+				"id"
 			],
 			"properties": {
 				"alias": {
@@ -10251,12 +10339,13 @@
 		},
 		"v1.ApplicationDeployResponse": {
 			"required": [
-				"status",
-				"createTime",
-				"version",
-				"note",
 				"envName",
 				"triggerType",
+				"workflowName",
+				"status",
+				"note",
+				"createTime",
+				"version",
 				"record"
 			],
 			"properties": {
@@ -10292,6 +10381,9 @@
 					"type": "string"
 				},
 				"version": {
+					"type": "string"
+				},
+				"workflowName": {
 					"type": "string"
 				}
 			}
@@ -10358,7 +10450,8 @@
 				"status",
 				"note",
 				"envName",
-				"triggerType"
+				"triggerType",
+				"workflowName"
 			],
 			"properties": {
 				"codeInfo": {
@@ -10390,6 +10483,9 @@
 					"type": "string"
 				},
 				"version": {
+					"type": "string"
+				},
+				"workflowName": {
 					"type": "string"
 				}
 			}
@@ -11034,13 +11130,13 @@
 		},
 		"v1.ConfigTemplateDetail": {
 			"required": [
+				"scope",
 				"sensitive",
 				"createTime",
 				"alias",
 				"name",
 				"namespace",
 				"description",
-				"scope",
 				"schema",
 				"uiSchema"
 			],
@@ -11870,8 +11966,8 @@
 		},
 		"v1.DetailAddonResponse": {
 			"required": [
-				"version",
 				"name",
+				"version",
 				"description",
 				"icon",
 				"invisible",
@@ -11954,13 +12050,13 @@
 		},
 		"v1.DetailApplicationResponse": {
 			"required": [
+				"project",
 				"description",
-				"updateTime",
+				"icon",
 				"name",
 				"alias",
-				"project",
 				"createTime",
-				"icon",
+				"updateTime",
 				"policies",
 				"envBindings",
 				"resourceInfo"
@@ -12017,20 +12113,20 @@
 		},
 		"v1.DetailClusterResponse": {
 			"required": [
-				"name",
-				"alias",
-				"apiServerURL",
 				"createTime",
-				"reason",
-				"provider",
-				"kubeConfigSecret",
-				"updateTime",
-				"description",
-				"labels",
-				"icon",
-				"status",
+				"apiServerURL",
 				"dashboardURL",
 				"kubeConfig",
+				"kubeConfigSecret",
+				"updateTime",
+				"name",
+				"alias",
+				"description",
+				"icon",
+				"labels",
+				"status",
+				"reason",
+				"provider",
 				"resourceInfo"
 			],
 			"properties": {
@@ -12088,14 +12184,14 @@
 		},
 		"v1.DetailComponentResponse": {
 			"required": [
-				"name",
-				"main",
+				"type",
 				"createTime",
-				"alias",
-				"updateTime",
+				"main",
 				"appPrimaryKey",
 				"creator",
-				"type",
+				"name",
+				"updateTime",
+				"alias",
 				"definition"
 			],
 			"properties": {
@@ -12183,12 +12279,12 @@
 		},
 		"v1.DetailDefinitionResponse": {
 			"required": [
-				"status",
-				"ownerAddon",
-				"alias",
 				"description",
 				"icon",
+				"ownerAddon",
 				"name",
+				"alias",
+				"status",
 				"labels",
 				"schema",
 				"uiSchema"
@@ -12246,15 +12342,15 @@
 		},
 		"v1.DetailPolicyResponse": {
 			"required": [
-				"name",
-				"type",
-				"creator",
-				"updateTime",
-				"envName",
-				"alias",
 				"description",
+				"creator",
+				"createTime",
+				"updateTime",
+				"name",
+				"alias",
+				"type",
 				"properties",
-				"createTime"
+				"envName"
 			],
 			"properties": {
 				"alias": {
@@ -12296,18 +12392,18 @@
 		},
 		"v1.DetailRevisionResponse": {
 			"required": [
-				"triggerType",
-				"revisionCRName",
 				"reason",
-				"status",
-				"envName",
-				"createTime",
-				"version",
-				"workflowName",
-				"updateTime",
-				"appPrimaryKey",
 				"deployUser",
-				"note"
+				"triggerType",
+				"envName",
+				"updateTime",
+				"version",
+				"revisionCRName",
+				"status",
+				"note",
+				"workflowName",
+				"createTime",
+				"appPrimaryKey"
 			],
 			"properties": {
 				"appPrimaryKey": {
@@ -12364,10 +12460,10 @@
 		},
 		"v1.DetailTargetResponse": {
 			"required": [
+				"updateTime",
 				"project",
 				"name",
-				"createTime",
-				"updateTime"
+				"createTime"
 			],
 			"properties": {
 				"alias": {
@@ -12407,11 +12503,11 @@
 		},
 		"v1.DetailUserResponse": {
 			"required": [
+				"name",
+				"email",
 				"disabled",
 				"createTime",
 				"lastLoginTime",
-				"name",
-				"email",
 				"projects",
 				"roles"
 			],
@@ -12452,14 +12548,14 @@
 		},
 		"v1.DetailWorkflowRecordResponse": {
 			"required": [
-				"applicationRevision",
+				"namespace",
 				"mode",
 				"workflowAlias",
-				"workflowName",
-				"name",
-				"namespace",
 				"status",
 				"message",
+				"name",
+				"applicationRevision",
+				"workflowName",
 				"deployTime",
 				"deployUser",
 				"note",
@@ -12521,14 +12617,14 @@
 		},
 		"v1.DetailWorkflowResponse": {
 			"required": [
-				"createTime",
-				"updateTime",
 				"mode",
-				"alias",
-				"description",
-				"envName",
 				"subMode",
 				"name",
+				"envName",
+				"createTime",
+				"updateTime",
+				"alias",
+				"description",
 				"enable",
 				"default"
 			],
@@ -12765,12 +12861,12 @@
 		},
 		"v1.GetPipelineResponse": {
 			"required": [
+				"name",
+				"alias",
 				"project",
 				"description",
 				"createTime",
 				"spec",
-				"name",
-				"alias",
 				"info"
 			],
 			"properties": {
@@ -12813,10 +12909,10 @@
 		},
 		"v1.GetPipelineRunLogResponse": {
 			"required": [
-				"id",
-				"name",
 				"type",
 				"phase",
+				"id",
+				"name",
 				"source",
 				"log"
 			],
@@ -13470,11 +13566,11 @@
 		},
 		"v1.LoginUserInfoResponse": {
 			"required": [
+				"lastLoginTime",
 				"name",
 				"email",
 				"disabled",
 				"createTime",
-				"lastLoginTime",
 				"projects",
 				"platformPermissions",
 				"projectPermissions"
@@ -13721,11 +13817,11 @@
 		},
 		"v1.PipelineListItem": {
 			"required": [
+				"createTime",
 				"name",
 				"alias",
 				"project",
 				"description",
-				"createTime",
 				"info"
 			],
 			"properties": {
@@ -13779,11 +13875,11 @@
 		},
 		"v1.PipelineMetaResponse": {
 			"required": [
+				"description",
 				"createTime",
 				"name",
 				"alias",
-				"project",
-				"description"
+				"project"
 			],
 			"properties": {
 				"alias": {
@@ -13806,13 +13902,13 @@
 		},
 		"v1.PipelineRun": {
 			"required": [
-				"contextValues",
-				"spec",
-				"pipelineRunName",
-				"pipelineName",
 				"project",
+				"pipelineRunName",
 				"record",
 				"contextName",
+				"contextValues",
+				"spec",
+				"pipelineName",
 				"status"
 			],
 			"properties": {
@@ -13848,9 +13944,9 @@
 		},
 		"v1.PipelineRunBase": {
 			"required": [
-				"pipelineRunName",
 				"pipelineName",
 				"project",
+				"pipelineRunName",
 				"record",
 				"contextName",
 				"contextValues",
@@ -14409,9 +14505,9 @@
 		},
 		"v1.SystemInfoResponse": {
 			"required": [
+				"platformID",
 				"enableCollection",
 				"loginType",
-				"platformID",
 				"systemVersion"
 			],
 			"properties": {
@@ -14935,13 +15031,13 @@
 		},
 		"v1.WorkflowRecord": {
 			"required": [
-				"workflowName",
-				"applicationRevision",
-				"mode",
+				"status",
 				"name",
 				"namespace",
+				"applicationRevision",
+				"mode",
+				"workflowName",
 				"workflowAlias",
-				"status",
 				"message"
 			],
 			"properties": {
@@ -15033,8 +15129,8 @@
 		},
 		"v1.WorkflowStep": {
 			"required": [
-				"type",
-				"name"
+				"name",
+				"type"
 			],
 			"properties": {
 				"alias": {

--- a/e2e-test/application_test.go
+++ b/e2e-test/application_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Test application rest api", func() {
 			Project:     appProject,
 			Description: "this is a test app",
 			Icon:        "",
-			Labels:      map[string]string{"test": "true"},
+			Labels:      map[string]string{"test": "true", "labelselector": "true"},
 			EnvBinding:  []*apisv1.EnvBinding{{Name: "dev-env"}},
 			Component: &apisv1.CreateComponentRequest{
 				Name:          "webservice",
@@ -85,7 +85,7 @@ var _ = Describe("Test application rest api", func() {
 
 	It("Test listing applications by label", func() {
 		defer GinkgoRecover()
-		res := get("/applications?labels=test=true")
+		res := get("/applications?labels=labelselector=true")
 		var apps apisv1.ListApplicationResponse
 		Expect(decodeResponseBody(res, &apps)).Should(Succeed())
 		Expect(cmp.Diff(len(apps.Applications), 1)).Should(BeEmpty())

--- a/e2e-test/application_test.go
+++ b/e2e-test/application_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Test application rest api", func() {
 
 	It("Test listing applications by label", func() {
 		defer GinkgoRecover()
-		res := get("/applications?labels=labelselector=true")
+		res := get("/applications?env=dev-env&labels=labelselector=true")
 		var apps apisv1.ListApplicationResponse
 		Expect(decodeResponseBody(res, &apps)).Should(Succeed())
 		Expect(cmp.Diff(len(apps.Applications), 1)).Should(BeEmpty())

--- a/e2e-test/application_test.go
+++ b/e2e-test/application_test.go
@@ -83,6 +83,14 @@ var _ = Describe("Test application rest api", func() {
 		Expect(cmp.Diff(appBase.Labels["test"], req.Labels["test"])).Should(BeEmpty())
 	})
 
+	It("Test listing applications by label", func() {
+		defer GinkgoRecover()
+		res := get("/applications?labels=test=true")
+		var apps apisv1.ListApplicationResponse
+		Expect(decodeResponseBody(res, &apps)).Should(Succeed())
+		Expect(cmp.Diff(len(apps.Applications), 1)).Should(BeEmpty())
+	})
+
 	It("Test listing components", func() {
 		defer GinkgoRecover()
 		res := get("/applications/" + appName + "/components")

--- a/packages/velaux-ui/src/locals/Zh/zh.json
+++ b/packages/velaux-ui/src/locals/Zh/zh.json
@@ -305,6 +305,7 @@
   "Search by Environment": "基于环境筛选",
   "Search by Target": "基于交付目标筛选",
   "Search by name and description etc": "基于名称、描述等筛选",
+  "Search by labels": "基于标签筛选",
   "Unrecoverable after deletion, are you sure to delete it?": "删除操作不可撤销，确认删除吗？",
   "Please enter the Environment name": "请输入环境名称",
   "Please enter the Environment alias": "请输入环境别名",

--- a/packages/velaux-ui/src/locals/Zh/zh.json
+++ b/packages/velaux-ui/src/locals/Zh/zh.json
@@ -620,5 +620,7 @@
   "contexts": "上下文参数",
   "Are you sure to rerun this Pipeline?": "确定要重新运行流水线吗？",
   "Show Values File": "查看 Value 文件",
-  "Showing the all projects that you have permissions": "你拥有权限的所有项目"
+  "Showing the all projects that you have permissions": "你拥有权限的所有项目",
+  "More": "显示更多",
+  "Hide": "收起"
 }

--- a/packages/velaux-ui/src/locals/Zh/zh.json
+++ b/packages/velaux-ui/src/locals/Zh/zh.json
@@ -304,8 +304,8 @@
   "Search by Project": "基于项目筛选",
   "Search by Environment": "基于环境筛选",
   "Search by Target": "基于交付目标筛选",
-  "Search by name and description etc": "基于名称、描述等筛选",
-  "Search by labels": "基于标签筛选",
+  "Search by Name and Description etc": "基于名称、描述等筛选",
+  "Search by Label Selector": "基于标签筛选",
   "Unrecoverable after deletion, are you sure to delete it?": "删除操作不可撤销，确认删除吗？",
   "Please enter the Environment name": "请输入环境名称",
   "Please enter the Environment alias": "请输入环境别名",
@@ -620,7 +620,7 @@
   "contexts": "上下文参数",
   "Are you sure to rerun this Pipeline?": "确定要重新运行流水线吗？",
   "Show Values File": "查看 Value 文件",
-  "Showing the all projects that you have permissions": "你拥有权限的所有项目",
+  "Showing all projects you are permitted": "你拥有权限的所有项目",
   "More": "显示更多",
   "Hide": "收起"
 }

--- a/packages/velaux-ui/src/pages/ApplicationList/components/CardContent/index.less
+++ b/packages/velaux-ui/src/pages/ApplicationList/components/CardContent/index.less
@@ -44,3 +44,11 @@
     }
   }
 }
+
+.table-content-label {
+  display: -webkit-box;
+  height: 25px;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}

--- a/packages/velaux-ui/src/pages/ApplicationList/components/CardContent/index.less
+++ b/packages/velaux-ui/src/pages/ApplicationList/components/CardContent/index.less
@@ -31,6 +31,14 @@
       -webkit-box-orient: vertical;
       -webkit-line-clamp: 2;
     }
+    .content-labels {
+      display: -webkit-box;
+      height: 70px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+    }
     .content-foot {
       padding: 16px 0 24px;
     }

--- a/packages/velaux-ui/src/pages/ApplicationList/components/CardContent/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationList/components/CardContent/index.tsx
@@ -3,7 +3,7 @@ import type { MouseEvent } from 'react';
 import React from 'react';
 import './index.less';
 import { Link } from 'dva/router';
-import { Grid, Card, Menu, Dropdown, Dialog, Button, Table } from '@alifd/next';
+import { Grid, Card, Menu, Dropdown, Dialog, Button, Table, Tag } from '@alifd/next';
 import { AiFillDelete, AiFillSetting } from 'react-icons/ai';
 
 import type { ShowMode } from '../..';
@@ -32,6 +32,7 @@ type Props = {
   editAppPlan: (item: ApplicationBase) => void;
   deleteAppPlan: (name: string) => void;
   setVisible: (visible: boolean) => void;
+  clickLabelFilter: (label: string) => void;
   showMode: ShowMode;
 };
 
@@ -63,6 +64,11 @@ class CardContent extends React.Component<Props, State> {
   onEditAppPlan = (item: ApplicationBase) => {
     this.props.editAppPlan(item);
   };
+
+  onClickLabelFilter = (label: string) => {
+    this.props.clickLabelFilter(label)
+  }
+
 
   isEditPermission = (item: ApplicationBase, button?: boolean) => {
     const { userInfo } = this.props;
@@ -166,7 +172,27 @@ class CardContent extends React.Component<Props, State> {
           return <span>{v}</span>;
         },
       },
-
+      {
+        key: 'labels',
+        title: <Translation>Tags</Translation>,
+        dataIndex: 'labels',
+        cell: (v: Record<string, string>) => {
+          return Object.keys(v).map((key) => {
+            if (v && key.indexOf("ux.oam.dev") < 0 && key.indexOf("app.oam.dev")) {
+              return (
+                <div>
+                  <Tag
+                    onClick={((e) => this.onClickLabelFilter(key+"="+`${v[key]}`))}
+                    key={key}
+                    style={{ margin: '4px' }}
+                    color="blue"
+                  >{`${key}=${v[key]}`}</Tag>
+                </div>
+              );
+            }
+          })
+        },
+      },
       {
         key: 'operation',
         title: <Translation>Actions</Translation>,
@@ -239,7 +265,7 @@ class CardContent extends React.Component<Props, State> {
     return (
       <Row wrap={true}>
         {applications?.map((item: ApplicationBase) => {
-          const { name, alias, icon, description, createTime, readOnly } = item;
+          const { name, alias, icon, description, createTime, readOnly, labels } = item;
           const showName = alias || name;
           return (
             <Col xl={6} m={8} s={12} xxs={24} className={`card-content-wrapper`} key={`${item.name}`}>
@@ -299,7 +325,21 @@ class CardContent extends React.Component<Props, State> {
                       {description}
                     </h4>
                   </Row>
-
+                  <Row className="content-labels">
+                    {labels &&
+                      Object.keys(labels).map((key) => {
+                        if (labels && key.indexOf("ux.oam.dev") < 0 && key.indexOf("app.oam.dev")) {
+                          return (
+                            <Tag
+                              onClick={((e) => this.onClickLabelFilter(key+"="+`${labels[key]}`))}
+                              key={key}
+                              style={{ margin: '4px' }}
+                              color="blue"
+                            >{`${key}=${labels[key]}`}</Tag>
+                          );
+                        }
+                      })}
+                  </Row>      
                   <Row className="content-foot colorA6A6A6">
                     <Col span="16">
                       <span>{createTime && momentDate(createTime)}</span>

--- a/packages/velaux-ui/src/pages/ApplicationList/components/SelectSearch/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationList/components/SelectSearch/index.tsx
@@ -15,6 +15,9 @@ type Props = {
   dispatch: ({}) => {};
   projects?: Project[];
   envs?: Env[];
+  appLabels?: string[];
+  labelValue?: string[];
+  setLabelValue: (labels: string[]) => void;
   getApplications: (params: any) => void;
   setMode: (mode: ShowMode) => void;
   showMode: ShowMode;
@@ -25,6 +28,7 @@ type State = {
   targetValue: string;
   inputValue: string;
   envValue: string;
+  labelValue: string[];
 };
 
 class SelectSearch extends React.Component<Props, State> {
@@ -35,10 +39,12 @@ class SelectSearch extends React.Component<Props, State> {
       targetValue: '',
       envValue: '',
       inputValue: '',
+      labelValue: [],
     };
     this.onChangeProject = this.onChangeProject.bind(this);
     this.onChangeTarget = this.onChangeTarget.bind(this);
     this.handleChangName = this.handleChangName.bind(this);
+    this.handleChangeLabel = this.handleChangeLabel.bind(this);
   }
 
   onChangeProject(e: string) {
@@ -69,6 +75,18 @@ class SelectSearch extends React.Component<Props, State> {
     });
   }
 
+  handleChangeLabel(value: string[]) {
+    const { setLabelValue } = this.props;
+    setLabelValue(value)
+    this.setState({
+      labelValue: value,
+    },
+    () => {
+      this.getApplications();
+    });
+
+  }
+
   onChangeEnv = (e: string) => {
     this.setState(
       {
@@ -85,26 +103,35 @@ class SelectSearch extends React.Component<Props, State> {
   };
 
   getApplications = async () => {
-    const { projectValue, inputValue, envValue } = this.state;
+    const { projectValue, inputValue, envValue, labelValue } = this.state;
+    const labelSelector = labelValue.join(",")
     const params = {
       project: projectValue,
       query: inputValue,
       env: envValue,
+      labels: labelSelector,
     };
     this.props.getApplications(params);
   };
 
   render() {
-    const { projects, envs, showMode } = this.props;
+    const { projects, appLabels, envs, showMode, labelValue } = this.props;
     const { projectValue, inputValue, envValue } = this.state;
 
     const projectPlaceholder = i18n.t('Search by Project').toString();
     const appPlaceholder = i18n.t('Search by name and description etc').toString();
     const envPlaceholder = i18n.t('Search by Environment').toString();
+    const labelPlaceholder = i18n.t('Search by labels').toString();
     const projectSource = projects?.map((item) => {
       return {
         label: item.alias || item.name,
         value: item.name,
+      };
+    });
+    const labelSource = appLabels?.map((item) => {
+      return {
+        label: item,
+        value: item,
       };
     });
 
@@ -116,7 +143,7 @@ class SelectSearch extends React.Component<Props, State> {
     });
     return (
       <Row className="app-select-wrapper border-radius-8" wrap={true}>
-        <Col xl={6} m={8} s={12} xxs={24} style={{ padding: '0 8px' }}>
+        <Col xl={6} m={4} s={6} xxs={12} style={{ padding: '0 8px' }}>
           <Select
             locale={locale().Select}
             mode="single"
@@ -129,7 +156,7 @@ class SelectSearch extends React.Component<Props, State> {
             value={projectValue}
           />
         </Col>
-        <Col xl={6} m={8} s={12} xxs={24} style={{ padding: '0 8px' }}>
+        <Col xl={6} m={4} s={6} xxs={12} style={{ padding: '0 8px' }}>
           <Select
             locale={locale().Select}
             mode="single"
@@ -140,6 +167,19 @@ class SelectSearch extends React.Component<Props, State> {
             className="item"
             hasClear
             value={envValue}
+          />
+        </Col>
+        <Col xl={6} m={8} s={12} xxs={24} style={{ padding: '0 8px' }}>
+          <Select
+            hasClear
+            size="large"
+            placeholder={labelPlaceholder}
+            onChange={this.handleChangeLabel}
+            showSearch
+            mode="multiple"
+            value={labelValue}
+            className="item"
+            dataSource={labelSource}
           />
         </Col>
         <Col xl={6} m={8} s={12} xxs={24} style={{ padding: '0 8px' }}>

--- a/packages/velaux-ui/src/pages/ApplicationList/components/SelectSearch/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationList/components/SelectSearch/index.tsx
@@ -77,9 +77,10 @@ class SelectSearch extends React.Component<Props, State> {
 
   handleChangeLabel(value: string[]) {
     const { setLabelValue } = this.props;
-    setLabelValue(value)
+    let label = value? value:[]
+    setLabelValue(label)
     this.setState({
-      labelValue: value,
+      labelValue: label,
     },
     () => {
       this.getApplications();

--- a/pkg/server/interfaces/api/application.go
+++ b/pkg/server/interfaces/api/application.go
@@ -19,6 +19,7 @@ package api
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"k8s.io/klog/v2"
 
@@ -687,11 +688,22 @@ func (c *application) listApplications(req *restful.Request, res *restful.Respon
 	if req.QueryParameter("project") != "" {
 		projetNames = append(projetNames, req.QueryParameter("project"))
 	}
+	labels := map[string]string{}
+	if req.QueryParameter("labels") != "" {
+		allLabels := strings.Split(req.QueryParameter("labels"), ",")
+		for _, label := range allLabels {
+			kv := strings.Split(label, "=")
+			if len(kv) == 2 {
+				labels[kv[0]] = kv[1]
+			}
+		}
+	}
 	apps, err := c.ApplicationService.ListApplications(req.Request.Context(), apis.ListApplicationOptions{
 		Projects:   projetNames,
 		Env:        req.QueryParameter("env"),
 		TargetName: req.QueryParameter("targetName"),
 		Query:      req.QueryParameter("query"),
+		Labels:     labels,
 	})
 	if err != nil {
 		bcode.ReturnError(req, res, err)

--- a/pkg/server/interfaces/api/dto/v1/types.go
+++ b/pkg/server/interfaces/api/dto/v1/types.go
@@ -388,10 +388,11 @@ type ClusterBase struct {
 
 // ListApplicationOptions list application  query options
 type ListApplicationOptions struct {
-	Projects   []string `json:"projects"`
-	Env        string   `json:"env"`
-	TargetName string   `json:"targetName"`
-	Query      string   `json:"query"`
+	Projects   []string          `json:"projects"`
+	Env        string            `json:"env"`
+	TargetName string            `json:"targetName"`
+	Query      string            `json:"query"`
+	Labels     map[string]string `json:"labels"`
 }
 
 // ListApplicationResponse list applications by query params


### PR DESCRIPTION
### Description of your changes

Close: #240 

support label-based selector for application management, hiding label with prefix `ux.oam.dev` and `app.oam.dev`

<img width="1244" alt="image" src="https://user-images.githubusercontent.com/93654253/226325850-8f48f001-d3c2-4d61-994d-202a7304a8f5.png">

in table mode, fold up labels in default

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/93654253/226533441-4919e082-c299-4731-8cd9-61aa5b8688ec.png">

expand all labels

<img width="1249" alt="image" src="https://user-images.githubusercontent.com/93654253/226533493-7e81de33-8bf7-4225-bc4b-62c0c91b39ec.png">

click label tag will invoke label filter
<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
