### PR TITLE
Feat: Support to proxy the dex server

### DIFF
--- a/e2e-test/plugin_test.go
+++ b/e2e-test/plugin_test.go
@@ -17,15 +17,18 @@ limitations under the License.
 package e2e_test
 
 import (
+	"fmt"
+
+	"cuelang.org/go/pkg/strings"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	apisv1 "github.com/kubevela/velaux/pkg/server/interfaces/api/dto/v1"
+	"github.com/kubevela/velaux/pkg/server/utils/bcode"
 )
 
-var _ = Describe("Test plugin rest api", func() {
-
+var _ = Describe("Test the plugin rest api", func() {
 	It("Test list installed plugins", func() {
 		defer GinkgoRecover()
 		res := get("/plugins")
@@ -41,5 +44,26 @@ var _ = Describe("Test plugin rest api", func() {
 		var dto apisv1.PluginDTO
 		Expect(decodeResponseBody(res, &dto)).Should(Succeed())
 		Expect(cmp.Diff(dto.Module, "plugins/app-demo/module")).Should(BeEmpty())
+	})
+})
+
+var _ = Describe("Test to request the plugin static files", func() {
+	It("Test to get the module file", func() {
+		defer GinkgoRecover()
+		res := get("/public/plugins/app-demo/module.js")
+		defer func() { _ = res.Body.Close() }()
+		Expect(cmp.Diff(res.StatusCode, 200)).Should(BeEmpty())
+	})
+})
+
+var _ = Describe("Test to request the dex plugin", func() {
+	It("Test to request the dex", func() {
+		defer GinkgoRecover()
+		res := get(baseDomain + "/dex/a")
+		var bcode bcode.Bcode
+		err := decodeResponseBody(res, &bcode)
+		fmt.Println(err.Error())
+		Expect(strings.HasPrefix(err.Error(), "response code is not 200")).Should(BeTrue())
+		Expect(cmp.Diff(bcode.BusinessCode, int32(404))).Should(BeEmpty())
 	})
 })

--- a/e2e-test/suite_test.go
+++ b/e2e-test/suite_test.go
@@ -180,10 +180,12 @@ func put(path string, body interface{}) *http.Response {
 
 func get(path string) *http.Response {
 	client := &http.Client{}
-	if !strings.HasPrefix(path, "/v1") {
-		path = baseURL + path
-	} else {
-		path = baseDomain + path
+	if !strings.HasPrefix(path, "http") {
+		if !strings.HasPrefix(path, "/v1") {
+			path = baseURL + path
+		} else {
+			path = baseDomain + path
+		}
 	}
 	req, err := http.NewRequest(http.MethodGet, path, nil)
 	Expect(err).Should(BeNil())
@@ -238,15 +240,14 @@ func decodeResponseBody(resp *http.Response, dst interface{}) error {
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("response code is not 200: %d body: %s", resp.StatusCode, string(body))
-	}
 	if dst != nil {
 		err = json.Unmarshal(body, dst)
 		if err != nil {
 			return err
 		}
-		return nil
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("response code is not 200: %d body: %s", resp.StatusCode, string(body))
 	}
 	return nil
 }

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -59,6 +59,8 @@ type Config struct {
 	WorkflowVersion string
 
 	PluginConfig PluginConfig
+
+	DexServerURL string
 }
 
 type PluginConfig struct {
@@ -96,6 +98,7 @@ func NewConfig() *Config {
 			CorePluginPath:   "core-plugins",
 			CustomPluginPath: []string{"plugins"},
 		},
+		DexServerURL: "http://dex.vela-system:5556",
 	}
 }
 
@@ -126,5 +129,6 @@ func (s *Config) AddFlags(fs *pflag.FlagSet, c *Config) {
 	fs.Float64Var(&s.KubeQPS, "kube-api-qps", c.KubeQPS, "the qps for kube clients. Low qps may lead to low throughput. High qps may give stress to api-server.")
 	fs.IntVar(&s.KubeBurst, "kube-api-burst", c.KubeBurst, "the burst for kube clients. Recommend setting it qps*3.")
 	fs.StringVar(&s.WorkflowVersion, "workflow-version", c.WorkflowVersion, "the version of workflow to meet controller requirement.")
+	fs.StringVar(&s.DexServerURL, "dex-server", c.DexServerURL, "the URL of the dex server.")
 	fs.StringArrayVar(&s.PluginConfig.CustomPluginPath, "plugin-path", c.PluginConfig.CustomPluginPath, "the path of the plugin directory")
 }

--- a/pkg/server/utils/bcode/bcode.go
+++ b/pkg/server/utils/bcode/bcode.go
@@ -83,7 +83,9 @@ func NewBcode(httpCode, businessCode int32, message string) *Bcode {
 
 // ReturnHTTPError Unified handling of all types of errors, generating a standard return structure.
 func ReturnHTTPError(req *http.Request, res http.ResponseWriter, err error) {
-	ReturnError(restful.NewRequest(req), restful.NewResponse(res), err)
+	restRes := restful.NewResponse(res)
+	restRes.SetRequestAccepts(restful.MIME_JSON)
+	ReturnError(restful.NewRequest(req), restRes, err)
 }
 
 // ReturnError Unified handling of all types of errors, generating a standard return structure.


### PR DESCRIPTION
### Description of your changes

The server support to proxy of the dex server. Users could config the server URL by command args.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [x] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
