### PR TITLE
Fix:Add a helm type of application, the warehouse drop-down box is empty

### DIFF
--- a/packages/velaux-ui/src/extends/HelmRepoSelect/index.tsx
+++ b/packages/velaux-ui/src/extends/HelmRepoSelect/index.tsx
@@ -38,7 +38,7 @@ class HelmRepoSelect extends Component<Props, State> {
   }
   componentDidMount() {
     if (!this.props.helm?.repoType || this.props.helm?.repoType == 'helm') {
-      this.onLoadRepos(this.props.helm?.repoType);
+      this.onLoadRepos(this.props.helm?.repoType || 'helm');
     }
   }
 


### PR DESCRIPTION
### Description of your changes

Add a helm type of application, the interface does return data but the warehouse drop-down box is empty。

![5f23](https://user-images.githubusercontent.com/55052467/228509681-8d2e75ab-e91f-4827-8d6f-926de0166437.png)

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
