### PR TITLE
Fix: 'Numbers' ui-type in default ui schema

### DIFF
--- a/packages/velaux-ui/src/components/UISchema/index.tsx
+++ b/packages/velaux-ui/src/components/UISchema/index.tsx
@@ -29,6 +29,7 @@ import PolicySelect from '../../extends/PolicySelect';
 import SecretKeySelect from '../../extends/SecretKeySelect';
 import SecretSelect from '../../extends/SecretSelect';
 import Strings from '../../extends/Strings';
+import Numbers from '../../extends/Numbers';
 import Structs from '../../extends/Structs';
 import type { Definition } from '../../interface/addon';
 import { checkImageName, replaceUrl } from '../../utils/common';
@@ -624,6 +625,17 @@ class UISchema extends Component<Props, State> {
           case 'Strings':
             return getGroup(
               <Strings
+                disabled={disableEdit}
+                key={param.jsonKey}
+                {...init(param.jsonKey, {
+                  initValue: initValue,
+                  rules: convertRule(param.validate),
+                })}
+              />
+            );
+          case 'Numbers':
+            return getGroup(
+              <Numbers
                 disabled={disableEdit}
                 key={param.jsonKey}
                 {...init(param.jsonKey, {

--- a/packages/velaux-ui/src/extends/Numbers/index.less
+++ b/packages/velaux-ui/src/extends/Numbers/index.less
@@ -1,0 +1,29 @@
+.number-container {
+    display: flex !important;
+    align-items: center;
+    margin-bottom: 8px;
+    background-color: #e2e2e2;
+    border: 1px solid #eee;
+    border-top-left-radius: 24px;
+    border-top-right-radius: 24px;
+    border-bottom-right-radius: 24px;
+    border-bottom-left-radius: 24px;
+    .next-input {
+      flex: 1 1 auto;
+    }
+    .remove-option-container {
+      flex: 0 0 36px;
+      text-align: center;
+    }
+    .next-icon-ashbin {
+      cursor: pointer;
+      &::before {
+        color: #fff;
+        font-size: 18px !important;
+      }
+    }
+  }
+  .add-btn-container {
+    text-align: right;
+  }
+  

--- a/packages/velaux-ui/src/extends/Numbers/index.tsx
+++ b/packages/velaux-ui/src/extends/Numbers/index.tsx
@@ -1,0 +1,159 @@
+import { Input, Button, Field } from '@alifd/next';
+import type { Rule } from '@alifd/field';
+import React from 'react';
+
+import './index.less';
+import { If } from '../../components/If';
+import Translation from '../../components/Translation';
+import { AiOutlineDelete } from 'react-icons/ai';
+
+type Props = {
+  label?: string;
+  value?: any;
+  id: string;
+  onChange: (value: any) => void;
+  disabled: boolean;
+};
+
+type InputParams = {
+  key: string;
+  id: string;
+  isFirst?: boolean;
+  label?: boolean;
+  value?: number;
+  onChange: () => {};
+  delete: (key: string) => {};
+  rules: Rule[];
+  disabled: boolean;
+};
+
+type ListParams = {
+  key: string;
+  value?: number;
+};
+
+type State = {
+  inputList: ListParams[];
+};
+
+function InputItem(props: InputParams) {
+  return (
+    <div className="number-container">
+      <Input
+        htmlType="number"
+        onChange={props.onChange}
+        className="input"
+        disabled={props.disabled}
+        value={props.value}
+      />
+      <div className="remove-option-container">
+        <If condition={!props.isFirst}>
+          <AiOutlineDelete
+            onClick={() => {
+              props.delete(props.id);
+            }}
+          />
+        </If>
+      </div>
+    </div>
+  );
+}
+
+class Numbers extends React.Component<Props, State> {
+  field: any;
+  constructor(props: Props) {
+    super(props);
+    const inputList: ListParams[] = [];
+    if (props.value) {
+      props.value.map((v: number, index: number) => {
+        const key = Date.now().toString() + index;
+        inputList.push({
+          key,
+          value: v,
+        });
+      });
+    }
+    this.state = {
+      inputList,
+    };
+    this.field = new Field(this, {
+      onChange: () => {
+        this.changeValues();
+      },
+    });
+  }
+
+  componentDidMount = async () => {};
+
+  changeValues = () => {
+    const values = this.field.getValues();
+    const inputList: ListParams[] = this.state.inputList;
+    Object.keys(values).map((key) => {
+      if (Array.isArray(inputList)) {
+        inputList.forEach((item) => {
+          if (item.key === key) {
+            item.value = values[key];
+          }
+        });
+      }
+    });
+    const valuesInfo = inputList.map((item: ListParams) => item.value);
+    this.props.onChange(valuesInfo);
+  };
+
+  addInputItem = () => {
+    const { inputList } = this.state;
+    const key = Date.now().toString();
+    inputList.push({
+      key,
+    });
+    this.setState({
+      inputList,
+    });
+  };
+
+  removeInputItem = (key: string) => {
+    const { inputList } = this.state;
+    inputList.forEach((item, i) => {
+      if (item.key === key) {
+        inputList.splice(i, 1);
+        this.field.remove(key);
+      }
+    });
+    this.setState(
+      {
+        inputList,
+      },
+      () => {
+        this.changeValues();
+      }
+    );
+  };
+
+  render() {
+    const { inputList } = this.state;
+    const { init } = this.field;
+    const { label, disabled } = this.props;
+    return (
+      <div>
+        {inputList.map((item) => (
+          <InputItem
+            {...init(item.key)}
+            key={item.key}
+            value={item.value}
+            delete={(id) => this.removeInputItem(id)}
+            id={item.key}
+            label={label}
+          />
+        ))}
+        <div className="add-btn-container">
+          <Button disabled={disabled} size="small" onClick={this.addInputItem} ghost="light">
+            <Translation>Add</Translation>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Numbers;


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #659

In vela-core default ui-type, number array will return ui-type `Numbers`, but velaux didn't implement ui-type `Numbers`.
```golang
case "array":
    if subType == "string" {
	    return "Strings"
    }
    if subType == "number" || subType == "integer" {
	    return "Numbers"
    }
    return "Structs"
```

The new ui-type preview:

<img width="1240" alt="image" src="https://user-images.githubusercontent.com/93654253/229724566-c4aa6548-8b06-4178-bb46-0e0217fa77e5.png">

Btw, i think the annotations in trait `expose` is optional, but default validate is required.

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
