### PR TITLE
Fix: The depends on options do not show properly when adding new component

### DIFF
--- a/packages/velaux-ui/src/pages/ApplicationConfig/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationConfig/index.tsx
@@ -285,6 +285,7 @@ class ApplicationConfig extends Component<Props, State> {
     this.setState({
       visibleComponent: true,
       isEditComponent: false,
+      componentName: '',
     });
   };
 


### PR DESCRIPTION
### Description of your changes
fix a bug : the depends on options do not show properly when adding new component after edit a component
![image](https://user-images.githubusercontent.com/10116106/230756075-005d9f7b-de52-4b57-af65-146ebd754e74.png)


Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
