### PR TITLE
Fix: enhance the canary rollout setting

### DIFF
--- a/packages/velaux-ui/src/api/application.ts
+++ b/packages/velaux-ui/src/api/application.ts
@@ -48,6 +48,9 @@ export function getApplicationDetails(params: any) {
 export function getApplicationStatus(params: { name: string; envName: string }) {
   return get(`${url}/${params.name}/envs/${params.envName}/status`, params).then((res) => res);
 }
+export function getApplicationAllStatus(params: { name: string }) {
+  return get(`${url}/${params.name}/status`, params).then((res) => res);
+}
 
 export function deleteApplication(params: { name: string }) {
   return rdelete(url + '/' + params.name, params);
@@ -58,17 +61,12 @@ export function getApplicationComponents(params: { appName: string }) {
   return get(`${url}/${appName}/components`, {}).then((res) => res);
 }
 
-export function createApplicationComponent(
-  params: ApplicationComponentConfig,
-  query: { appName: string },
-) {
+export function createApplicationComponent(params: ApplicationComponentConfig, query: { appName: string }) {
   return post(`${url}/${query.appName}/components`, params).then((res) => res);
 }
 
 export function getComponentDetails(params: any) {
-  return post(`${url}/${params.name}/components/${params.componentName}`, params).then(
-    (res) => res,
-  );
+  return post(`${url}/${params.name}/components/${params.componentName}`, params).then((res) => res);
 }
 
 export function deployApplication(params: ApplicationDeployRequest, customError?: boolean) {
@@ -134,16 +132,12 @@ export function createTrait(params: Trait, query: TraitQuery) {
 
 export function updateTrait(params: Trait, query: TraitQuery) {
   const { appName, componentName, traitType } = query;
-  return put(`${url}/${appName}/components/${componentName}/traits/${traitType}`, params).then(
-    (res) => res,
-  );
+  return put(`${url}/${appName}/components/${componentName}/traits/${traitType}`, params).then((res) => res);
 }
 
 export function deleteTrait(query: TraitQuery) {
   const { appName, componentName, traitType } = query;
-  return rdelete(`${url}/${appName}/components/${componentName}/traits/${traitType}`, {}).then(
-    (res) => res,
-  );
+  return rdelete(`${url}/${appName}/components/${componentName}/traits/${traitType}`, {}).then((res) => res);
 }
 
 export function listRevisions(query: ListRevisionQuery) {
@@ -171,22 +165,14 @@ export function getApplicationWorkflowRecord(params: { appName: string }) {
 
 export function updateComponentProperties(
   params: ApplicationComponentConfig,
-  query: { appName: string; componentName: string },
+  query: { appName: string; componentName: string }
 ) {
-  return put(`${url}/${query.appName}/components/${query.componentName}`, params).then(
-    (res) => res,
-  );
+  return put(`${url}/${query.appName}/components/${query.componentName}`, params).then((res) => res);
 }
 
-export function resumeApplicationWorkflowRecord(params: {
-  appName: string;
-  workflowName: string;
-  recordName: string;
-}) {
+export function resumeApplicationWorkflowRecord(params: { appName: string; workflowName: string; recordName: string }) {
   const { appName, workflowName, recordName } = params;
-  return get(`${url}/${appName}/workflows/${workflowName}/records/${recordName}/resume`, {}).then(
-    (res) => res,
-  );
+  return get(`${url}/${appName}/workflows/${workflowName}/records/${recordName}/resume`, {}).then((res) => res);
 }
 
 export function rollbackApplicationWorkflowRecord(params: {
@@ -195,9 +181,7 @@ export function rollbackApplicationWorkflowRecord(params: {
   recordName: string;
 }) {
   const { appName, workflowName, recordName } = params;
-  return get(`${url}/${appName}/workflows/${workflowName}/records/${recordName}/rollback`, {}).then(
-    (res) => res,
-  );
+  return get(`${url}/${appName}/workflows/${workflowName}/records/${recordName}/rollback`, {}).then((res) => res);
 }
 
 export function terminateApplicationWorkflowRecord(params: {
@@ -206,10 +190,7 @@ export function terminateApplicationWorkflowRecord(params: {
   recordName: string;
 }) {
   const { appName, workflowName, recordName } = params;
-  return get(
-    `${url}/${appName}/workflows/${workflowName}/records/${recordName}/terminate`,
-    {},
-  ).then((res) => res);
+  return get(`${url}/${appName}/workflows/${workflowName}/records/${recordName}/terminate`, {}).then((res) => res);
 }
 
 export function getApplicationTriggers(params: { appName: string }) {
@@ -226,10 +207,7 @@ export function createTrigger(params: CreateTriggerRequest, query: { appName: st
   return post(`${url}/${appName}/triggers`, params).then((res) => res);
 }
 
-export function updateTrigger(
-  params: UpdateTriggerRequest,
-  query: { appName: string; token: string },
-) {
+export function updateTrigger(params: UpdateTriggerRequest, query: { appName: string; token: string }) {
   const { appName, token } = query;
   return put(`${url}/${appName}/triggers/${token}`, params).then((res) => res);
 }
@@ -240,9 +218,7 @@ export function deleteTrigger(params: { appName: string; token: string }) {
 }
 
 export function deleteComponent(query: { appName: string; componentName: string }) {
-  return rdelete(`${url}/${query.appName}/components/${query.componentName}`, {}).then(
-    (res) => res,
-  );
+  return rdelete(`${url}/${query.appName}/components/${query.componentName}`, {}).then((res) => res);
 }
 
 export function compareApplication(appName: string, params: ApplicationCompareRequest) {

--- a/packages/velaux-ui/src/api/application.ts
+++ b/packages/velaux-ui/src/api/application.ts
@@ -163,6 +163,20 @@ export function getApplicationWorkflowRecord(params: { appName: string }) {
   return get(`${url}/${params.appName}/records`, params).then((res) => res);
 }
 
+export function getApplicationEnvRecords(params: {
+  appName: string;
+  envName: string;
+  pageSize?: number;
+  page?: number;
+}) {
+  return get(`${url}/${params.appName}/envs/${params.envName}/records`, {
+    params: {
+      pageSize: params.pageSize || 20,
+      page: params.page || 1,
+    },
+  }).then((res) => res);
+}
+
 export function updateComponentProperties(
   params: ApplicationComponentConfig,
   query: { appName: string; componentName: string }

--- a/packages/velaux-ui/src/api/workflows.ts
+++ b/packages/velaux-ui/src/api/workflows.ts
@@ -2,7 +2,7 @@ import type { UpdateWorkflowRequest } from '../interface/application';
 import { getDomain } from '../utils/common';
 
 import { application, definition } from './productionLink';
-import { get, rdelete, put } from './request';
+import { get, rdelete, put, post } from './request';
 
 const baseURLOject = getDomain();
 const base = baseURLOject.APIBASE;
@@ -12,12 +12,14 @@ export function listWorkflow(params: { appName: string }) {
   return get(url, {}).then((res) => res);
 }
 
-export function updateWorkflow(
-  pathParams: { appName: string; workflowName: string },
-  params: UpdateWorkflowRequest,
-) {
+export function updateWorkflow(pathParams: { appName: string; workflowName: string }, params: UpdateWorkflowRequest) {
   const url = base + `${application}/${pathParams.appName}/workflows/${pathParams.workflowName}`;
   return put(url, params).then((res) => res);
+}
+
+export function createWorkflow(pathParams: { appName: string }, params: UpdateWorkflowRequest) {
+  const url = base + `${application}/${pathParams.appName}/workflows`;
+  return post(url, params).then((res) => res);
 }
 
 export function getEnvWorkflowRecord(params: { appName: string; workflowName: string }) {
@@ -30,26 +32,13 @@ export function detailWorkflow(params: { appName: string; name: string }) {
   return get(url, {});
 }
 
-export function detailWorkflowRecord(params: {
-  appName: string;
-  workflowName: string;
-  record: string;
-}) {
-  const url =
-    base +
-    `${application}/${params.appName}/workflows/${params.workflowName}/records/${params.record}`;
+export function detailWorkflowRecord(params: { appName: string; workflowName: string; record: string }) {
+  const url = base + `${application}/${params.appName}/workflows/${params.workflowName}/records/${params.record}`;
   return get(url, {});
 }
 
-export function getWorkflowRecordLogs(params: {
-  appName: string;
-  workflowName: string;
-  record: string;
-  step: string;
-}) {
-  const url =
-    base +
-    `${application}/${params.appName}/workflows/${params.workflowName}/records/${params.record}/logs`;
+export function getWorkflowRecordLogs(params: { appName: string; workflowName: string; record: string; step: string }) {
+  const url = base + `${application}/${params.appName}/workflows/${params.workflowName}/records/${params.record}/logs`;
   return get(url, { params: { step: params.step } });
 }
 
@@ -60,8 +49,7 @@ export function getWorkflowRecordInputs(params: {
   step: string;
 }) {
   const url =
-    base +
-    `${application}/${params.appName}/workflows/${params.workflowName}/records/${params.record}/inputs`;
+    base + `${application}/${params.appName}/workflows/${params.workflowName}/records/${params.record}/inputs`;
   return get(url, { params: { step: params.step } });
 }
 
@@ -72,8 +60,7 @@ export function getWorkflowRecordOutputs(params: {
   step: string;
 }) {
   const url =
-    base +
-    `${application}/${params.appName}/workflows/${params.workflowName}/records/${params.record}/outputs`;
+    base + `${application}/${params.appName}/workflows/${params.workflowName}/records/${params.record}/outputs`;
   return get(url, { params: { step: params.step } });
 }
 

--- a/packages/velaux-ui/src/components/PipelineGraph/components/step.tsx
+++ b/packages/velaux-ui/src/components/PipelineGraph/components/step.tsx
@@ -39,10 +39,11 @@ export const Step = (props: StepProps) => {
       <If condition={group}>
         <div className="step-title">{step.name || step.id}</div>
         <div className="groups" style={{ width: stepWidth + 'px', minHeight: '70px' }}>
-          {step.subSteps?.map((subStep) => {
+          {step.subSteps?.map((subStep, index) => {
             return (
               <div
                 className="step-status"
+                key={'step-' + (subStep.id || subStep.name) + index}
                 onClick={(event) => {
                   onNodeClick(subStep);
                   event.stopPropagation();

--- a/packages/velaux-ui/src/components/PipelineGraph/index.less
+++ b/packages/velaux-ui/src/components/PipelineGraph/index.less
@@ -33,9 +33,8 @@
       background-color: var(--color-workflow-step-bg);
       border-top-left-radius: 6px;
       border-top-right-radius: 6px;
-      box-shadow: inset 0 1px 0 var(--color-border-default),
-        inset 1px 0 0 var(--color-border-default), inset -1px 0 0 var(--color-border-default),
-        0 -1px 2px var(--color-workflow-step-header-shadow);
+      box-shadow: inset 0 1px 0 var(--color-border-default), inset 1px 0 0 var(--color-border-default),
+        inset -1px 0 0 var(--color-border-default), 0 -1px 2px var(--color-workflow-step-header-shadow);
       transition: background-color ease-out 0.12s, box-shadow ease-out 0.12s;
       &:after {
         position: absolute;
@@ -45,8 +44,8 @@
         height: 16px;
         margin-left: 16px;
         border-bottom-left-radius: 6px;
-        box-shadow: inset 1px 0 0 var(--color-border-default),
-          inset 0 -1px 0 var(--color-border-default), -1px 3px var(--color-workflow-step-bg);
+        box-shadow: inset 1px 0 0 var(--color-border-default), inset 0 -1px 0 var(--color-border-default),
+          -1px 3px var(--color-workflow-step-bg);
         transition: box-shadow ease-out 0.12s;
         content: '';
       }
@@ -54,8 +53,10 @@
     .groups {
       position: relative;
       padding: var(--padding-common);
-      transition: background-color ease-out 0.12s, border-color ease-out 0.12s,
-        box-shadow ease-out 0.12s;
+      transition: background-color ease-out 0.12s, border-color ease-out 0.12s, box-shadow ease-out 0.12s;
+      .mode {
+        text-align: center;
+      }
     }
     .workflow-step-port {
       position: absolute;

--- a/packages/velaux-ui/src/components/UISchema/index.tsx
+++ b/packages/velaux-ui/src/components/UISchema/index.tsx
@@ -969,7 +969,7 @@ class UISchema extends Component<Props, State> {
     });
     const formItemLayout = {
       labelCol: {
-        fixedSpan: 10,
+        fixedSpan: 5,
       },
       wrapperCol: {
         span: 14,

--- a/packages/velaux-ui/src/components/WorkflowStudio/index.less
+++ b/packages/velaux-ui/src/components/WorkflowStudio/index.less
@@ -50,6 +50,9 @@
   .sub-step-add {
     text-align: center;
     border: 1px dashed var(--grey-300);
+    &:hover {
+      background: #f6f4ed;
+    }
   }
 }
 

--- a/packages/velaux-ui/src/components/WorkflowStudio/input-item.tsx
+++ b/packages/velaux-ui/src/components/WorkflowStudio/input-item.tsx
@@ -73,7 +73,7 @@ export const InputItems = (props: { value?: InputItem[]; id: string; onChange: (
     <div id={props.id} className="input-items">
       {items?.map((item, index) => {
         return (
-          <div className="item">
+          <div className="item" key={'input' + index}>
             <InputItemForm
               key={item.from}
               value={item}

--- a/packages/velaux-ui/src/components/WorkflowStudio/step-form.tsx
+++ b/packages/velaux-ui/src/components/WorkflowStudio/step-form.tsx
@@ -129,7 +129,7 @@ class StepForm extends Component<Props, State> {
         onOk={this.onSubmit}
         extButtons={[
           <Button key={'cancel'} style={{ marginRight: '16px' }} onClick={onClose}>
-            Cancel
+            <Translation>Cancel</Translation>
           </Button>,
         ]}
       >

--- a/packages/velaux-ui/src/components/WorkflowStudio/step.tsx
+++ b/packages/velaux-ui/src/components/WorkflowStudio/step.tsx
@@ -75,9 +75,9 @@ export const Step = (props: StepProps) => {
           )}
           {step.subSteps?.map((subStep, index) => {
             return (
-              <div>
+              <div key={subStep.name + '-step'}>
                 <div
-                  key={subStep.name}
+                  key={subStep.name + '-status'}
                   className="step-status"
                   onClick={(event) => {
                     onNodeClick(subStep, true);

--- a/packages/velaux-ui/src/components/WorkflowStudio/step.tsx
+++ b/packages/velaux-ui/src/components/WorkflowStudio/step.tsx
@@ -11,9 +11,12 @@ import { showAlias } from '../../utils/common';
 import { If } from '../If';
 import { AiOutlineDelete } from 'react-icons/ai';
 import { IoMdAdd } from 'react-icons/io';
+import { Translation } from '../../components/Translation';
+import { WorkflowMode } from '../../interface/application';
 
 export interface StepProps {
   step: WorkflowStep;
+  subMode?: WorkflowMode;
   output: boolean;
   input: boolean;
   probeState: {
@@ -23,13 +26,14 @@ export interface StepProps {
   group: boolean;
   onNodeClick: (step: WorkflowStep, sub: boolean) => void;
   onDelete: (stepName: string) => void;
-  onAddSubStep: () => void;
+  onAddSubStep: (index: number) => void;
 }
 
 export const Step = (props: StepProps) => {
-  const { step, output, input, onNodeClick, group, onDelete, onAddSubStep } = props;
+  const { step, output, input, onNodeClick, group, onDelete, onAddSubStep, subMode } = props;
   const { stepWidth, stepInterval } = props.probeState;
   const [isActive, setActive] = useState(false);
+  const mode: WorkflowMode = step.mode || subMode || 'DAG';
   return (
     <div
       className={classNames('step', { active: isActive }, { group: group })}
@@ -64,35 +68,49 @@ export const Step = (props: StepProps) => {
           </span>
         </div>
         <div className="groups" style={{ width: stepWidth + 'px' }}>
-          {step.subSteps?.map((subStep) => {
+          {mode && (
+            <div className="mode">
+              <Translation>Mode</Translation>:<Translation>{mode}</Translation>
+            </div>
+          )}
+          {step.subSteps?.map((subStep, index) => {
             return (
-              <div
-                key={subStep.name}
-                className="step-status"
-                onClick={(event) => {
-                  onNodeClick(subStep, true);
-                  event.stopPropagation();
-                }}
-              >
-                <StepTypeIcon type={subStep.type} />
-                <div className="step-name">{subStep.alias || subStep.name}</div>
+              <div>
                 <div
-                  className="step-delete"
+                  key={subStep.name}
+                  className="step-status"
                   onClick={(event) => {
-                    onDelete(subStep.name);
+                    onNodeClick(subStep, true);
                     event.stopPropagation();
                   }}
                 >
-                  <AiOutlineDelete size={14} />
+                  <StepTypeIcon type={subStep.type} />
+                  <div className="step-name">{subStep.alias || subStep.name}</div>
+                  <div
+                    className="step-delete"
+                    onClick={(event) => {
+                      onDelete(subStep.name);
+                      event.stopPropagation();
+                    }}
+                  >
+                    <AiOutlineDelete size={14} />
+                  </div>
                 </div>
+                {mode == 'StepByStep' && (
+                  <div className="sub-step-add" onClick={() => onAddSubStep(index + 1)}>
+                    <IoMdAdd size={14} />
+                  </div>
+                )}
               </div>
             );
           })}
-          <div className="step-status sub-step-add" onClick={onAddSubStep}>
-            <div className="step-name">
-              <IoMdAdd size={14} />
+          {(mode === 'DAG' || !step.subSteps) && (
+            <div className="step-status sub-step-add" onClick={() => onAddSubStep(step.subSteps?.length || 0)}>
+              <div className="step-name">
+                <IoMdAdd size={14} />
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </If>
       <If condition={!group}>

--- a/packages/velaux-ui/src/components/WorkflowYAML/index.tsx
+++ b/packages/velaux-ui/src/components/WorkflowYAML/index.tsx
@@ -1,6 +1,6 @@
 import { Message } from '@alifd/next';
 import * as yaml from 'js-yaml';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import type { WorkflowStep } from '../../interface/pipeline';
 import DefinitionCode from '../DefinitionCode';
@@ -13,7 +13,14 @@ type Props = {
 };
 export const WorkflowYAML = (props: Props) => {
   const id = 'workflow:' + props.name;
-  const content = yaml.dump(props.steps);
+  const [content, setContent] = useState<string>();
+  useEffect(() => {
+    try {
+      const c = yaml.dump(props.steps);
+      setContent(c);
+    } catch {}
+  }, [props.steps]);
+
   return (
     <div>
       <Message type="help">

--- a/packages/velaux-ui/src/extends/ComponentSelect/index.tsx
+++ b/packages/velaux-ui/src/extends/ComponentSelect/index.tsx
@@ -1,6 +1,6 @@
 import { Select } from '@alifd/next';
-import { connect } from 'dva';
 import React from 'react';
+import { UISchemaContext } from '../../context';
 
 import { getApplicationComponents } from '../../api/application';
 import i18n from '../../i18n';
@@ -12,16 +12,12 @@ type Props = {
   id: string;
   onChange: (value: string[]) => void;
   disabled: boolean;
-  appName?: string;
 };
 
 type State = {
   componentOptions: Array<{ label: string; value: string }>;
 };
 
-@connect((store: any) => {
-  return { ...store.uischema };
-})
 class ComponentSelect extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -35,7 +31,7 @@ class ComponentSelect extends React.Component<Props, State> {
   };
 
   fetchComponentList = async () => {
-    const { appName } = this.props;
+    const { appName = '' } = this.context;
     if (appName) {
       getApplicationComponents({
         appName: appName,
@@ -89,5 +85,7 @@ class ComponentSelect extends React.Component<Props, State> {
     );
   }
 }
+
+ComponentSelect.contextType = UISchemaContext;
 
 export default ComponentSelect;

--- a/packages/velaux-ui/src/interface/application.ts
+++ b/packages/velaux-ui/src/interface/application.ts
@@ -104,6 +104,11 @@ export interface ApplicationRollbackResponse {
   record: WorkflowRecordBase;
 }
 
+export interface ApplicationEnvStatus {
+  envName: string;
+  status: ApplicationStatus;
+}
+
 export interface ApplicationStatus {
   conditions: Condition[];
   status:

--- a/packages/velaux-ui/src/interface/application.ts
+++ b/packages/velaux-ui/src/interface/application.ts
@@ -197,6 +197,17 @@ export interface UpdateWorkflowRequest {
   default?: boolean;
 }
 
+export interface CreateWorkflowRequest {
+  name: string;
+  envName: string;
+  alias?: string;
+  description?: string;
+  mode: WorkflowMode;
+  subMode: WorkflowMode;
+  steps: WorkflowStep[];
+  default?: boolean;
+}
+
 export interface Trait {
   alias?: string;
   description?: string;
@@ -318,7 +329,7 @@ export interface Workflow {
   enable: boolean;
   mode: WorkflowMode;
   subMode: WorkflowMode;
-  steps?: WorkflowStep[];
+  steps: WorkflowStep[];
 }
 
 export interface UpdateComponentProperties {

--- a/packages/velaux-ui/src/interface/pipeline.ts
+++ b/packages/velaux-ui/src/interface/pipeline.ts
@@ -1,4 +1,4 @@
-import type { Condition, InputItem, OutputItem, WorkflowStepStatus } from './application';
+import type { Condition, InputItem, OutputItem, WorkflowMode, WorkflowStepStatus } from './application';
 import type { NameAlias } from './env';
 
 export interface CreatePipelineRequest {
@@ -116,12 +116,13 @@ export interface WorkflowStepBase {
 }
 
 export interface WorkflowStep extends WorkflowStepBase {
+  mode?: WorkflowMode;
   subSteps?: WorkflowStepBase[];
 }
 
 interface PipelineRunMode {
-  steps?: 'DAG' | 'StepByStep';
-  subSteps?: 'DAG' | 'StepByStep';
+  steps?: WorkflowMode;
+  subSteps?: WorkflowMode;
 }
 
 export type RunPhase =

--- a/packages/velaux-ui/src/layout/Application/components/DeployConfig/index.less
+++ b/packages/velaux-ui/src/layout/Application/components/DeployConfig/index.less
@@ -13,11 +13,24 @@
       border: 1px solid var(--primary-color) !important;
     }
   }
+  .deploy-workflow-select-item-title {
+    display: inline-flex;
+    .deploy-notice {
+      color: var(--grey-300);
+      display: flex;
+      align-items: center;
+      margin-left: var(--spacing-4);
+    }
+  }
   .deploy-workflow-select-item {
     display: flex;
     padding: var(--spacing-4) 0;
     justify-content: space-between;
     flex-flow: row nowrap;
+    align-items: center;
+    .status {
+      display: inline;
+    }
     .env {
       flex-grow: 1;
       width: 100px;
@@ -25,11 +38,6 @@
       justify-content: end;
       align-items: center;
     }
-  }
-  .deploy-notice {
-    color: var(--grey-300);
-    display: flex;
-    align-items: center;
     .enable-canary-deploy {
       margin-left: var(--spacing-4);
     }

--- a/packages/velaux-ui/src/layout/Application/components/DeployConfig/index.less
+++ b/packages/velaux-ui/src/layout/Application/components/DeployConfig/index.less
@@ -4,7 +4,7 @@
     .next-radio-wrapper {
       width: 100%;
       margin-bottom: 8px;
-      padding: var(--spacing-4) var(--spacing-4) 0 var(--spacing-4);
+      padding: var(--spacing-4);
       border: 1px solid #c0c6cc !important;
       border-radius: 4px;
       cursor: pointer;
@@ -15,6 +15,8 @@
   }
   .deploy-workflow-select-item-title {
     display: inline-flex;
+    justify-content: space-between;
+    width: 90%;
     .deploy-notice {
       color: var(--grey-300);
       display: flex;

--- a/packages/velaux-ui/src/layout/Application/components/DeployConfig/index.tsx
+++ b/packages/velaux-ui/src/layout/Application/components/DeployConfig/index.tsx
@@ -33,8 +33,8 @@ interface Props {
   applicationAllStatus?: ApplicationEnvStatus[];
   onClose: () => void;
   onOK: (workflowName?: string, force?: boolean) => void;
-  workflows?: Workflow[];
-  envBindings?: EnvBinding[];
+  workflows: Workflow[];
+  envBindings: EnvBinding[];
   dispatch: Dispatch;
   loading: boolean;
 }
@@ -69,11 +69,15 @@ function checkCanaryDeployStep(w: Workflow): boolean {
 class DeployConfigDialog extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
+    let defaultEnv = props.envName;
+    if (!defaultEnv && props.envBindings.length > 0) {
+      defaultEnv = props.envBindings[0].name;
+    }
     this.state = {
       workflowName: '',
       dryRunLoading: false,
       showDryRunResult: false,
-      env: props.envName,
+      env: defaultEnv,
     };
   }
 
@@ -142,7 +146,7 @@ class DeployConfigDialog extends Component<Props, State> {
     const createReq: CreateWorkflowRequest = _.cloneDeep(base);
     createReq.name = createReq.name + '-canary';
     createReq.alias = createReq.alias?.replace('Workflow', 'Canary Workflow');
-
+    createReq.default = false;
     createWorkflow({ appName: applicationDetail.name }, createReq).then((res) => {
       if (res) {
         this.loadApplicationWorkflows();
@@ -195,9 +199,6 @@ class DeployConfigDialog extends Component<Props, State> {
         return { label: showAlias(env), value: env.name };
       }) || [];
 
-    if (!env && envOptions.length > 0) {
-      this.setState({ env: envOptions[0].value });
-    }
     const workflowOptions = workflows?.filter((w) => w.envName === env);
 
     const status = env && envStatus[env] ? envStatus[env].status : 'Undeployed';

--- a/packages/velaux-ui/src/layout/Application/components/Header/index.tsx
+++ b/packages/velaux-ui/src/layout/Application/components/Header/index.tsx
@@ -17,6 +17,7 @@ import type {
   WorkflowRecord,
   ApplicationDeployResponse,
   ApplicationEnvStatus,
+  EnvBinding,
 } from '../../../../interface/application';
 import type { APIError } from '../../../../utils/errors';
 import { handleError } from '../../../../utils/errors';
@@ -29,9 +30,11 @@ const { Row, Col } = Grid;
 interface Props {
   currentPath: string;
   appName: string;
+  envName?: string;
   applicationDetail?: ApplicationDetail;
   applicationAllStatus?: ApplicationEnvStatus[];
   workflows?: Workflow[];
+  envbinding?: EnvBinding[];
   dispatch: Dispatch;
 }
 
@@ -95,7 +98,7 @@ class ApplicationHeader extends Component<Props, State> {
       )
         .then((re: ApplicationDeployResponse) => {
           if (re) {
-            Message.success('Application deployed successfully');
+            Message.success(i18n.t('Application deployed successfully'));
             this.onGetApplicationDetails();
             if (re.record && re.record.name && dispatch) {
               dispatch(
@@ -129,7 +132,8 @@ class ApplicationHeader extends Component<Props, State> {
   componentWillUnmount() {}
 
   render() {
-    const { applicationDetail, applicationAllStatus, currentPath, workflows, appName, dispatch } = this.props;
+    const { applicationDetail, applicationAllStatus, currentPath, workflows, envbinding, appName, envName, dispatch } =
+      this.props;
     const { showDeployConfig, loading } = this.state;
     const activeKey = currentPath.substring(currentPath.lastIndexOf('/') + 1);
     let item = <Translation>{`app-${activeKey}`}</Translation>;
@@ -191,8 +195,10 @@ class ApplicationHeader extends Component<Props, State> {
           {applicationDetail && (
             <DeployConfig
               loading={loading}
+              envName={envName}
               applicationAllStatus={applicationAllStatus}
               applicationDetail={applicationDetail}
+              envBindings={envbinding}
               onClose={() => {
                 this.setState({ showDeployConfig: false });
               }}

--- a/packages/velaux-ui/src/layout/Application/components/Header/index.tsx
+++ b/packages/velaux-ui/src/layout/Application/components/Header/index.tsx
@@ -192,7 +192,7 @@ class ApplicationHeader extends Component<Props, State> {
           </Col>
         </Row>
         <If condition={showDeployConfig}>
-          {applicationDetail && (
+          {applicationDetail && envbinding && workflows && (
             <DeployConfig
               loading={loading}
               envName={envName}

--- a/packages/velaux-ui/src/layout/Application/index.tsx
+++ b/packages/velaux-ui/src/layout/Application/index.tsx
@@ -134,7 +134,7 @@ class ApplicationLayout extends Component<Props, any> {
     }
     return (
       <div className="app-layout">
-        <Header dispatch={dispatch} appName={appName} currentPath={url} />
+        <Header dispatch={dispatch} appName={appName} envName={envName} currentPath={url} />
         <EnvTabs dispatch={dispatch} appName={appName} activeKey={envName ? envName : 'basisConfig'} />
         <Row className="padding16 main">
           <div className="menu">

--- a/packages/velaux-ui/src/layout/Application/index.tsx
+++ b/packages/velaux-ui/src/layout/Application/index.tsx
@@ -1,7 +1,6 @@
 import { Loading, Grid } from '@alifd/next';
 import { connect } from 'dva';
 import React, { Component } from 'react';
-
 import EnvTabs from './components/EnvTabs';
 import Header from './components/Header';
 import Menus from './components/Menus';
@@ -53,6 +52,7 @@ class ApplicationLayout extends Component<Props, any> {
           this.loadApplicationEnvbinding();
           this.loadApplicationWorkflows();
           this.loadApplicationPolicies();
+          this.loadApplicationStatus();
         });
       },
     });
@@ -103,6 +103,16 @@ class ApplicationLayout extends Component<Props, any> {
     } = this.props.match;
     this.props.dispatch({
       type: 'application/getApplicationWorkflows',
+      payload: { appName: appName },
+    });
+  };
+
+  loadApplicationStatus = async () => {
+    const {
+      params: { appName },
+    } = this.props.match;
+    this.props.dispatch({
+      type: 'application/getApplicationAllStatus',
       payload: { appName: appName },
     });
   };

--- a/packages/velaux-ui/src/layout/LayoutRouter/index.tsx
+++ b/packages/velaux-ui/src/layout/LayoutRouter/index.tsx
@@ -170,7 +170,7 @@ export default function Router() {
       />
       <Route
         exact
-        path="/applications/:appName/envbinding/:envName/workflow/studio"
+        path="/applications/:appName/envbinding/:envName/workflow/:workflowName/studio"
         render={(props: any) => {
           return (
             <ApplicationLayout {...props}>

--- a/packages/velaux-ui/src/locals/Zh/zh.json
+++ b/packages/velaux-ui/src/locals/Zh/zh.json
@@ -623,12 +623,18 @@
   "Are you sure to rerun this Pipeline?": "确定要重新运行流水线吗？",
   "Show Values File": "查看 Value 文件",
   "Showing all projects you are permitted": "你拥有权限的所有项目",
-  "More": "显示更多",
+  "More": "更多",
   "Hide": "收起",
   "Admin Username": "管理员账号名称",
   "The default canary rollout is powered by kruise-rollout addon, let's enable it first.": "金丝雀发布默认由 kruise-rollout 插件提供支持，请先启用该插件。",
   "You can also edit the workflow directly to switch to canary deploy mode.": "直接编辑工作流也可以切换为金丝雀发布模式。",
   "There is no deploy steps exist.": "工作流缺少 Deploy 步骤。",
   "Batch Setting": "批次设置",
-  "Canary Rollout Setting": "金丝雀发布设置"
+  "Canary Rollout Setting": "金丝雀发布设置",
+  "Enable Canary Rollout": "启用金丝雀发布",
+  "Select Workflow": "选择工作流",
+  "Canary Rollout": "金丝雀发布",
+  "Default Rollout": "常规发布",
+  "UnDeployed": "未部署",
+  "Advanced Configs": "高级配置"
 }

--- a/packages/velaux-ui/src/locals/Zh/zh.json
+++ b/packages/velaux-ui/src/locals/Zh/zh.json
@@ -641,5 +641,6 @@
   "Workflow updated successfully": "工作流更新成功",
   "Workflow removed successfully": "工作流删除成功",
   "The canary rollout workflow is available when the application is running": "金丝雀发布工作流仅在应用处于运行态时可用",
-  "This workflow needs your approving": "工作流执行需要你审批"
+  "This workflow needs your approving": "工作流执行需要你审批",
+  "Project allow isolate the user permissions and applications.": "项目用于隔离用户权限和应用"
 }

--- a/packages/velaux-ui/src/locals/Zh/zh.json
+++ b/packages/velaux-ui/src/locals/Zh/zh.json
@@ -635,6 +635,11 @@
   "Select Workflow": "选择工作流",
   "Canary Rollout": "金丝雀发布",
   "Default Rollout": "常规发布",
-  "UnDeployed": "未部署",
-  "Advanced Configs": "高级配置"
+  "Undeployed": "未部署",
+  "Advanced Configs": "高级配置",
+  "Step Count": "步骤数量",
+  "Workflow updated successfully": "工作流更新成功",
+  "Workflow removed successfully": "工作流删除成功",
+  "The canary rollout workflow is available when the application is running": "金丝雀发布工作流仅在应用处于运行态时可用",
+  "This workflow needs your approving": "工作流执行需要你审批"
 }

--- a/packages/velaux-ui/src/model/application.js
+++ b/packages/velaux-ui/src/model/application.js
@@ -4,6 +4,7 @@ import {
   createApplication,
   getApplicationDetails,
   getApplicationStatus,
+  getApplicationAllStatus,
   getApplicationComponents,
   getPolicyList,
   getApplicationEnvbinding,
@@ -18,6 +19,7 @@ export default {
     applicationList: [],
     applicationDetail: {},
     applicationStatus: {},
+    applicationAllStatus: [],
     projectList: [],
     clusterList: [],
     searchAppName: '',
@@ -57,6 +59,12 @@ export default {
       return {
         ...state,
         applicationStatus: payload.status,
+      };
+    },
+    updateApplicationAllStatus(state, { type, payload }) {
+      return {
+        ...state,
+        applicationAllStatus: payload.status,
       };
     },
     updateComponents(state, { type, payload }) {
@@ -140,6 +148,14 @@ export default {
       const { appName, envName } = action.payload;
       const result = yield call(getApplicationStatus, { name: appName, envName: envName });
       yield put({ type: 'updateApplicationStatus', payload: result });
+      if (action.callback) {
+        action.callback(result);
+      }
+    },
+    *getApplicationAllStatus(action, { call, put }) {
+      const { appName, envName } = action.payload;
+      const result = yield call(getApplicationAllStatus, { name: appName, envName: envName });
+      yield put({ type: 'updateApplicationAllStatus', payload: result });
       if (action.callback) {
         action.callback(result);
       }

--- a/packages/velaux-ui/src/pages/Addons/components/registry-manage/index.tsx
+++ b/packages/velaux-ui/src/pages/Addons/components/registry-manage/index.tsx
@@ -244,10 +244,9 @@ class RegistryManageDialog extends React.Component<Props, State> {
             <Table.Column width="150px" title={<Translation>Name</Translation>} dataIndex="name" />
             <Table.Column width="80px" title={<Translation>Type</Translation>} dataIndex="type" />
             <Table.Column title={<Translation>URL</Translation>} dataIndex="url" />
-            <If condition={registryDataSource.find((item) => item.type === 'Gitlab')}>
-              <Table.Column width="100px" title={<Translation>Repository name</Translation>} dataIndex="repo" />
-            </If>
-
+            {registryDataSource.find((item) => item.type === 'Gitlab') && (
+              <Table.Column width="100px" title={<Translation>Repository Name</Translation>} dataIndex="repo" />
+            )}
             <Table.Column width="160px" title={<Translation>Path(Bucket)</Translation>} dataIndex="path" />
             <Table.Column
               cell={renderAction}
@@ -317,7 +316,7 @@ class RegistryManageDialog extends React.Component<Props, State> {
                 <If condition={selectType === 'Gitlab'}>
                   <Col span={3} style={{ padding: '8px' }}>
                     <Form.Item
-                      label={<Translation>Repository name</Translation>}
+                      label={<Translation>Repository Name</Translation>}
                       required
                       help="Repository name in gitlab"
                     >

--- a/packages/velaux-ui/src/pages/ApplicationLog/components/LogContainer/index.less
+++ b/packages/velaux-ui/src/pages/ApplicationLog/components/LogContainer/index.less
@@ -11,10 +11,9 @@
   .next-switch {
     margin-top: 8px;
   }
-}
-
-.next-btn {
-  margin-right: 8px !important;
+  .download {
+    margin-right: var(--spacing-4);
+  }
 }
 
 .logBox {

--- a/packages/velaux-ui/src/pages/ApplicationLog/components/LogContainer/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationLog/components/LogContainer/index.tsx
@@ -142,13 +142,13 @@ class ContainerLog extends Component<Props, State> {
   downloadLog = () => {
     const { pod, activeContainerName = '' } = this.props;
     const { logs } = this.state;
-    
+
     let logContent: string[] = [];
     logs.map((line) => {
       logContent.push(line.content);
     });
 
-    downloadStringFile(logContent.join("\n"), pod?.metadata.name + "-" + activeContainerName);
+    downloadStringFile(logContent.join('\n'), pod?.metadata.name + '-' + activeContainerName);
   };
 
   render() {
@@ -157,8 +157,8 @@ class ContainerLog extends Component<Props, State> {
     return (
       <Fragment>
         <div className="application-logs-actions">
-          <Button type="normal" size="small" onClick={this.downloadLog}>
-            <Icon type="download"/>
+          <Button className="download" type="normal" size="small" onClick={this.downloadLog}>
+            <Icon type="download" />
           </Button>
           <Checkbox checked={showTimestamps} onChange={(v) => this.setState({ showTimestamps: v })}>
             <Translation className="font-bold font-size-14">Show timestamps</Translation>

--- a/packages/velaux-ui/src/pages/ApplicationStatus/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationStatus/index.tsx
@@ -1,7 +1,6 @@
 import { Table, Card, Loading, Balloon, Button, Message, Dialog, Tag, Tab } from '@alifd/next';
 import { connect } from 'dva';
 import { Link, routerRedux } from 'dva/router';
-import i18next from 'i18next';
 import React from 'react';
 
 import { deployApplication } from '../../api/application';
@@ -230,7 +229,7 @@ class ApplicationStatusPage extends React.Component<Props, State> {
       )
         .then((re: ApplicationDeployResponse) => {
           if (re) {
-            Message.success(i18next.t('Application deployed successfully'));
+            Message.success(i18n.t('Application deployed successfully'));
             this.setState({ deployLoading: false });
             this.loadApplicationStatus();
             if (re.record && re.record.name && dispatch) {
@@ -243,7 +242,7 @@ class ApplicationStatusPage extends React.Component<Props, State> {
         .catch((err: APIError) => {
           if (err.BusinessCode === 10004) {
             Dialog.confirm({
-              content: i18next.t('Workflow is executing. Do you want to force a restart?').toString(),
+              content: i18n.t('Workflow is executing. Do you want to force a restart?').toString(),
               onOk: () => {
                 this.onDeploy(true);
               },
@@ -257,7 +256,7 @@ class ApplicationStatusPage extends React.Component<Props, State> {
           }
         });
     } else {
-      Message.warning(i18next.t('Please wait'));
+      Message.warning(i18n.t('Please wait'));
     }
   };
 

--- a/packages/velaux-ui/src/pages/ApplicationWorkflowStatus/components/WorkflowRecord/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationWorkflowStatus/components/WorkflowRecord/index.tsx
@@ -386,7 +386,9 @@ class ApplicationWorkflowRecord extends React.Component<Props, State> {
               </If>
               <If condition={showRecord?.status === 'suspending'}>
                 <div className={classNames('suspend-actions')}>
-                  <div className="desc">This Workflow need you approve.</div>
+                  <div className="desc">
+                    <Translation>This workflow needs your approving</Translation>
+                  </div>
                   <Button.Group>
                     <Button
                       type="secondary"

--- a/packages/velaux-ui/src/pages/ApplicationWorkflowStatus/components/WorkflowRecord/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationWorkflowStatus/components/WorkflowRecord/index.tsx
@@ -539,7 +539,7 @@ class ApplicationWorkflowRecord extends React.Component<Props, State> {
                     )}
                   </div>
                 </Tab.Item>
-                <Tab.Item title="Properties" key={'properties'}>
+                <Tab.Item title={i18n.t('Properties').toString()} key={'properties'}>
                   <div className="step-info padding16">
                     <tbody>
                       {properties &&
@@ -554,7 +554,7 @@ class ApplicationWorkflowRecord extends React.Component<Props, State> {
                     </tbody>
                   </div>
                 </Tab.Item>
-                <Tab.Item title="Outputs" key={'outputs'}>
+                <Tab.Item title={i18n.t('Outputs')} key={'outputs'}>
                   <If condition={!outputLoading && (!outputs || !outputs.values || outputs.values.length == 0)}>
                     <Empty hideIcon message={'There are no outputs.'} />
                   </If>
@@ -581,7 +581,7 @@ class ApplicationWorkflowRecord extends React.Component<Props, State> {
                     </div>
                   </Loading>
                 </Tab.Item>
-                <Tab.Item title="Inputs" key={'inputs'}>
+                <Tab.Item title={i18n.t('Inputs')} key={'inputs'}>
                   <If condition={!inputLoading && (!inputs || !inputs?.values || inputs.values.length == 0)}>
                     <Empty hideIcon message={'There are no inputs.'} />
                   </If>

--- a/packages/velaux-ui/src/pages/ApplicationWorkflowStudio/components/CanarySetting/index.less
+++ b/packages/velaux-ui/src/pages/ApplicationWorkflowStudio/components/CanarySetting/index.less
@@ -4,6 +4,7 @@
 .canary-step {
   display: flex;
   justify-content: space-between;
+  margin-bottom: var(--spacing-4);
   .source,
   .target {
     display: flex;
@@ -15,6 +16,7 @@
   .source {
     margin-right: 32px;
     position: relative;
+    width: 100%;
     &::after {
       content: '';
       position: absolute;

--- a/packages/velaux-ui/src/pages/ApplicationWorkflowStudio/components/CanarySetting/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationWorkflowStudio/components/CanarySetting/index.tsx
@@ -27,7 +27,7 @@ const generateCanaryDeployGroup = (step: WorkflowStep, batch: number): WorkflowS
   const policies: string[] | null = step.properties ? step.properties['policies'] : null;
   for (let i = 0; i < batch; i++) {
     const batchStep: WorkflowStep = {
-      name: 'batch-' + i,
+      name: step.name + '-batch-' + i,
       alias: 'Batch ' + i,
       type: DeployModes.CanaryDeploy,
       properties: {
@@ -38,7 +38,7 @@ const generateCanaryDeployGroup = (step: WorkflowStep, batch: number): WorkflowS
     if (policies && batchStep.properties) {
       batchStep.properties['policies'] = _.cloneDeep(policies);
     }
-    const approveStep: WorkflowStep = { name: 'approve-' + i, alias: 'Approve ' + i, type: 'suspend' };
+    const approveStep: WorkflowStep = { name: step.name + '-approve-' + i, alias: 'Approve ' + i, type: 'suspend' };
     if (i > 0) {
       steps.push(approveStep);
     }

--- a/packages/velaux-ui/src/pages/ApplicationWorkflowStudio/components/CanarySetting/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationWorkflowStudio/components/CanarySetting/index.tsx
@@ -3,7 +3,7 @@ import { Dialog, Form, Grid, Message, NumberPicker } from '@alifd/next';
 import { DeployModes } from '@velaux/data';
 import _ from 'lodash';
 import i18n from '../../../../i18n';
-import { Workflow, WorkflowMode } from '../../../../interface/application';
+import { Workflow } from '../../../../interface/application';
 import { WorkflowStep } from '../../../../interface/pipeline';
 import { locale } from '../../../../utils/locale';
 import './index.less';

--- a/packages/velaux-ui/src/pages/ApplicationWorkflowStudio/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationWorkflowStudio/index.tsx
@@ -30,7 +30,7 @@ const ButtonGroup = Button.Group;
 
 type Props = {
   dispatch: Dispatch<any>;
-  match: { params: { appName: string; envName: string } };
+  match: { params: { appName: string; envName: string; workflowName: string } };
   applicationDetail?: ApplicationDetail;
   envbinding: EnvBinding[];
 };
@@ -92,12 +92,19 @@ class ApplicationWorkflowStudio extends React.Component<Props, State> {
 
   loadWorkflow = () => {
     const {
-      params: { appName },
+      params: { appName, workflowName },
     } = this.props.match;
-    const env = this.getEnvbindingByName();
-    if (env && env.workflow.name) {
-      detailWorkflow({ appName: appName, name: env.workflow.name }).then((res: Workflow) => {
-        this.setState({ workflow: res, mode: res.mode, subMode: res.subMode, steps: res.steps });
+    detailWorkflow({ appName: appName, name: workflowName }).then((res: Workflow) => {
+      this.setState({ workflow: res, mode: res.mode, subMode: res.subMode, steps: res.steps });
+    });
+  };
+
+  loadApplicationWorkflows = async () => {
+    const { applicationDetail } = this.props;
+    if (applicationDetail) {
+      this.props.dispatch({
+        type: 'application/getApplicationWorkflows',
+        payload: { appName: applicationDetail.name },
       });
     }
   };
@@ -143,8 +150,9 @@ class ApplicationWorkflowStudio extends React.Component<Props, State> {
       )
         .then((res) => {
           if (res) {
-            Message.success('Workflow updated successfully');
+            Message.success(i18n.t('Workflow updated successfully'));
             this.loadWorkflow();
+            this.loadApplicationWorkflows();
             this.setState({ changed: false });
           }
         })

--- a/packages/velaux-ui/src/pages/ApplicationWorkflowStudio/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationWorkflowStudio/index.tsx
@@ -230,14 +230,18 @@ class ApplicationWorkflowStudio extends React.Component<Props, State> {
                   <Translation>Unsaved changes</Translation>
                 </div>
               )}
-              <MenuButton style={{ marginRight: 'var(--spacing-4)' }} autoWidth={false} label="More">
+              <MenuButton
+                style={{ marginRight: 'var(--spacing-4)' }}
+                autoWidth={false}
+                label={i18n.t('More').toString()}
+              >
                 <MenuButton.Item
                   onClick={() => {
                     locationService.partial({ setCanary: true });
                     this.setState({ setCanary: true });
                   }}
                 >
-                  <Translation>Canary Setting</Translation>
+                  <Translation>Canary Rollout Setting</Translation>
                 </MenuButton.Item>
               </MenuButton>
               <Form.Item label={i18n.t('Mode').toString()} labelAlign="inset" style={{ marginRight: '8px' }}>
@@ -277,7 +281,12 @@ class ApplicationWorkflowStudio extends React.Component<Props, State> {
               workflow: workflow as WorkflowData,
             }}
           >
-            <WorkflowStudio definitions={definitions} steps={steps} onChange={this.onChange} />
+            <WorkflowStudio
+              subMode={workflow.subMode}
+              definitions={definitions}
+              steps={steps}
+              onChange={this.onChange}
+            />
           </WorkflowContext.Provider>
         )}
         {workflow && editMode === 'yaml' && (

--- a/packages/velaux-ui/src/pages/MyProjectList/index.tsx
+++ b/packages/velaux-ui/src/pages/MyProjectList/index.tsx
@@ -1,10 +1,9 @@
-import { Table, Button, Dialog, Message } from '@alifd/next';
+import { Table, Dialog, Message } from '@alifd/next';
 import { Link } from 'dva/router';
 import React, { Fragment, Component } from 'react';
 
 import { deleteProject } from '../../api/project';
 import { ListTitle as Title } from '../../components/ListTitle';
-import Permission from '../../components/Permission';
 import { Translation } from '../../components/Translation';
 import type { NameAlias } from '../../interface/env';
 import type { Project } from '../../interface/project';
@@ -12,6 +11,7 @@ import { momentDate } from '../../utils/common';
 import { locale } from '../../utils/locale';
 import { connect } from 'dva';
 import { LoginUserInfo } from '../../interface/user';
+import i18n from '../../i18n';
 
 type Props = {
   dispatch: ({}) => void;
@@ -110,29 +110,6 @@ class MyProjectList extends Component<Props, State> {
           return <span>{v && v.alias ? `${v.alias}(${v.name})` : v.name}</span>;
         },
       },
-      {
-        key: 'operation',
-        title: <Translation>Actions</Translation>,
-        dataIndex: 'operation',
-        cell: (v: string, i: number, record: Project) => {
-          return (
-            <Fragment>
-              <Permission request={{ resource: `project:${record.name}`, action: 'delete' }} project={`${record.name}`}>
-                <Button
-                  text
-                  size={'medium'}
-                  component={'a'}
-                  onClick={() => {
-                    this.onDelete(record);
-                  }}
-                >
-                  <Translation>Delete</Translation>
-                </Button>
-              </Permission>
-            </Fragment>
-          );
-        },
-      },
     ];
 
     const { Column } = Table;
@@ -141,7 +118,10 @@ class MyProjectList extends Component<Props, State> {
     return (
       <Fragment>
         <div className="project-list-content">
-          <Title title="My Projects" subTitle="Showing the all projects that you have permissions" />
+          <Title
+            title="My Projects"
+            subTitle={i18n.t('Project allow isolate the user permissions and applications.')}
+          />
           <Table locale={locale().Table} dataSource={userInfo?.projects} loading={isLoading}>
             {columns.map((col, key) => (
               <Column {...col} key={key} align={'left'} />

--- a/packages/velaux-ui/src/pages/PipelineStudio/index.tsx
+++ b/packages/velaux-ui/src/pages/PipelineStudio/index.tsx
@@ -261,6 +261,7 @@ class PipelineStudio extends React.Component<Props, State> {
               }}
             >
               <WorkflowStudio
+                subMode={pipeline.spec.mode?.subSteps}
                 definitions={definitions}
                 steps={_.cloneDeep(pipeline.spec.steps)}
                 onChange={this.onChange}

--- a/pkg/server/interfaces/api/application.go
+++ b/pkg/server/interfaces/api/application.go
@@ -439,9 +439,9 @@ func (c *application) GetWebServiceRoute() *restful.WebService {
 		Filter(c.RbacService.CheckPerm("envBinding", "detail")).
 		Filter(c.appCheckFilter).
 		Param(ws.PathParameter("appName", "identifier of the application ").DataType("string")).
-		Returns(200, "OK", []*apis.ApplicationStatusResponse{}).
+		Returns(200, "OK", apis.ApplicationStatusListResponse{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
-		Writes([]*apis.ApplicationStatusResponse{}))
+		Writes(apis.ApplicationStatusListResponse{}))
 
 	ws.Route(ws.POST("/{appName}/envs/{envName}/recycle").To(c.recycleApplicationEnv).
 		Doc("recycle application env").
@@ -1130,7 +1130,7 @@ func (c *application) getApplicationStatusFromAllEnvs(req *restful.Request, res 
 		return
 	}
 
-	if err := res.WriteEntity(status); err != nil {
+	if err := res.WriteEntity(apis.ApplicationStatusListResponse{Status: status}); err != nil {
 		bcode.ReturnError(req, res, err)
 		return
 	}

--- a/pkg/server/interfaces/api/assembler/v1/do2dto.go
+++ b/pkg/server/interfaces/api/assembler/v1/do2dto.go
@@ -168,6 +168,7 @@ func ConvertFromRecordModel(record *model.WorkflowRecord) *apisv1.WorkflowRecord
 func ConvertFromWorkflowStepModel(step model.WorkflowStep) apisv1.WorkflowStep {
 	apiStep := apisv1.WorkflowStep{
 		WorkflowStepBase: ConvertFromWorkflowStepBaseModel(step.WorkflowStepBase),
+		Mode:             string(step.Mode),
 		SubSteps:         make([]apisv1.WorkflowStepBase, 0),
 	}
 	if step.Properties != nil {

--- a/pkg/server/interfaces/api/assembler/v1/dto2do.go
+++ b/pkg/server/interfaces/api/assembler/v1/dto2do.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"github.com/kubevela/velaux/pkg/server/domain/model"
 	apisv1 "github.com/kubevela/velaux/pkg/server/interfaces/api/dto/v1"
+	"github.com/kubevela/workflow/api/v1alpha1"
 )
 
 // CreateEnvBindingModel assemble the EnvBinding model from DTO
@@ -51,6 +52,7 @@ func CreateWorkflowStepModel(apiSteps []apisv1.WorkflowStep) ([]model.WorkflowSt
 		}
 		stepModel := model.WorkflowStep{
 			WorkflowStepBase: *base,
+			Mode:             v1alpha1.WorkflowMode(step.Mode),
 			SubSteps:         make([]model.WorkflowStepBase, 0),
 		}
 		for _, sub := range step.SubSteps {

--- a/pkg/server/interfaces/api/assembler/v1/dto2do.go
+++ b/pkg/server/interfaces/api/assembler/v1/dto2do.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1
 
 import (
+	"github.com/kubevela/workflow/api/v1alpha1"
+
 	"github.com/kubevela/velaux/pkg/server/domain/model"
 	apisv1 "github.com/kubevela/velaux/pkg/server/interfaces/api/dto/v1"
-	"github.com/kubevela/workflow/api/v1alpha1"
 )
 
 // CreateEnvBindingModel assemble the EnvBinding model from DTO

--- a/pkg/server/interfaces/api/dto/v1/types.go
+++ b/pkg/server/interfaces/api/dto/v1/types.go
@@ -471,10 +471,15 @@ type AppDryRunResponse struct {
 	Message string `json:"message,omitempty"`
 }
 
-// ApplicationStatusResponse application status response body
+// ApplicationStatusResponse application env status response body
 type ApplicationStatusResponse struct {
 	EnvName string            `json:"envName"`
 	Status  *common.AppStatus `json:"status"`
+}
+
+// ApplicationStatusListResponse the all env status of an application
+type ApplicationStatusListResponse struct {
+	Status []*ApplicationStatusResponse `json:"status"`
 }
 
 // ApplicationStatisticsResponse application statistics response body
@@ -1037,6 +1042,7 @@ type UpdateWorkflowRequest struct {
 // WorkflowStep workflow step config
 type WorkflowStep struct {
 	WorkflowStepBase `json:",inline"`
+	Mode             string             `json:"mode,omitempty" validate:"checkMode"`
 	SubSteps         []WorkflowStepBase `json:"subSteps,omitempty"`
 }
 

--- a/pkg/server/interfaces/api/dto/v1/types.go
+++ b/pkg/server/interfaces/api/dto/v1/types.go
@@ -1019,14 +1019,14 @@ type PolicyDefinition struct {
 
 // CreateWorkflowRequest create workflow  request
 type CreateWorkflowRequest struct {
-	Name        string         `json:"name"  validate:"checkname"`
-	Alias       string         `json:"alias"  validate:"checkalias" optional:"true"`
+	Name        string         `json:"name" validate:"checkname"`
+	Alias       string         `json:"alias" validate:"checkalias" optional:"true"`
 	Description string         `json:"description" optional:"true"`
 	Steps       []WorkflowStep `json:"steps,omitempty"`
 	Mode        string         `json:"mode" validate:"oneof=DAG StepByStep"`
 	SubMode     string         `json:"subMode" validate:"oneof=DAG StepByStep"`
 	Default     *bool          `json:"default"`
-	EnvName     string         `json:"envName"`
+	EnvName     string         `json:"envName" validate:"checkname"`
 }
 
 // UpdateWorkflowRequest update or create application workflow

--- a/pkg/server/interfaces/api/validate.go
+++ b/pkg/server/interfaces/api/validate.go
@@ -53,6 +53,9 @@ func init() {
 	if err := validate.RegisterValidation("checkpassword", ValidatePassword); err != nil {
 		panic(err)
 	}
+	if err := validate.RegisterValidation("checkMode", ValidateWorkflowMode); err != nil {
+		panic(err)
+	}
 }
 
 // ValidatePayloadType check PayloadType
@@ -114,4 +117,16 @@ func ValidatePassword(fl validator.FieldLevel) bool {
 		}
 	}
 	return letter && num
+}
+
+// ValidateWorkflowMode the sub step mode can be empty.
+func ValidateWorkflowMode(fl validator.FieldLevel) bool {
+	value := fl.Field().String()
+	if value == "" {
+		return true
+	}
+	if value == "DAG" || value == "StepByStep" {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
### Description of your changes

1. Support guiding to create the canary rollout workflow. Users could select a workflow to deploy the application.
2. Support adding the sub-step after any existing step.
3. Set the canary-deploy step mode is StepByStep.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [x] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

/cc @wangyikewxgm 
