### PR TITLE
Feat: Move the grafana navigation to the extension workspace

### DIFF
--- a/addon/metadata.yaml
+++ b/addon/metadata.yaml
@@ -1,5 +1,5 @@
 name: velaux
-version: v1.8.0-beta.1
+version: v1.8.0-rc.1
 description: KubeVela User Experience (UX). An extensible, application-oriented delivery and management Platform.
 icon: https://static.kubevela.net/images/logos/KubeVela%20-03.png
 url: https://kubevela.io

--- a/addon/resources/server.cue
+++ b/addon/resources/server.cue
@@ -45,7 +45,7 @@ _httpsTrait: *[ if parameter["secretName"] != _|_ && parameter["domain"] != _|_ 
 	type: "https-route"
 	properties: {
 		domains: [ parameter["domain"]]
-		rules: [{port: 80}]
+		rules: [{port: 8000}]
 		secrets: [{
 			name: parameter["secretName"]
 		}]

--- a/packages/velaux-data/src/types/menus.ts
+++ b/packages/velaux-data/src/types/menus.ts
@@ -24,6 +24,7 @@ export interface Menu {
   name: string;
   label: string;
   to: string;
+  href?: string;
   relatedRoute: Route[];
   icon?: string | React.ReactNode;
   permission?: ResourceAction;

--- a/packages/velaux-ui/src/layout/Header/index.tsx
+++ b/packages/velaux-ui/src/layout/Header/index.tsx
@@ -12,8 +12,6 @@ import {
   AiOutlineQuestionCircle,
 } from 'react-icons/ai';
 
-import { getConfigs } from '../../api/config';
-import grafanaImg from '../../assets/grafana.svg';
 import logo from '../../assets/kubevela-logo-white.png';
 import { If } from '../../components/If';
 import Permission from '../../components/Permission';
@@ -26,7 +24,6 @@ import type { SystemInfo } from '../../interface/system';
 import type { LoginUserInfo } from '../../interface/user';
 import { getData, setData } from '../../utils/cache';
 import { locale } from '../../utils/locale';
-import { checkPermission } from '../../utils/permission';
 import { getBrowserNameAndVersion } from '../../utils/utils';
 import CloudShell from '../CloudShell';
 import { locationService } from '../../services/LocationService';
@@ -97,17 +94,6 @@ class Header extends Component<Props, State> {
     });
   };
 
-  loadGrafanaIntegration = () => {
-    const { userInfo } = this.props;
-    if (checkPermission({ resource: 'config', action: 'list' }, '', userInfo)) {
-      getConfigs('grafana').then((res) => {
-        if (res && res.configs) {
-          this.setState({ grafanaConfigs: res.configs });
-        }
-      });
-    }
-  };
-
   telemetryDataCollection = async () => {
     const { systemInfo } = this.props;
     if (!getData(TelemetryDataCollectionKey) && systemInfo?.enableCollection) {
@@ -154,7 +140,6 @@ class Header extends Component<Props, State> {
     this.props.dispatch({
       type: 'user/getLoginUserInfo',
       callback: () => {
-        this.loadGrafanaIntegration();
         this.loadWorkspaces();
       },
     });
@@ -215,7 +200,7 @@ class Header extends Component<Props, State> {
   render() {
     const { Row } = Grid;
     const { show, userInfo, mode, currentWorkspace } = this.props;
-    const { grafanaConfigs, workspaces } = this.state;
+    const { workspaces } = this.state;
 
     return (
       <div className="layout-top-bar" id="layout-top-bar">
@@ -240,19 +225,6 @@ class Header extends Component<Props, State> {
           </div>
           <div style={{ flex: '1 1 0%' }}>
             <div className="workspace-items">
-              {grafanaConfigs?.map((config) => {
-                if (config.properties && config.properties.endpoint) {
-                  return (
-                    <div key={'config' + config.name} className="item" title={config.description}>
-                      <a target="_blank" href={config.properties.endpoint} rel="noopener noreferrer">
-                        <img src={grafanaImg} />
-                        <span>{config.alias || config.name}</span>
-                      </a>
-                    </div>
-                  );
-                }
-                return null;
-              })}
               {workspaces.map((ws) => {
                 return (
                   <Link


### PR DESCRIPTION
### Description of your changes

Move the grafana navigation from the top bar to the extension workspace.

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [x] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
