### PR TITLE
Fix: The sub length of the dex user more than 31

### DIFF
--- a/pkg/server/domain/service/authentication.go
+++ b/pkg/server/domain/service/authentication.go
@@ -492,8 +492,14 @@ func (d *dexHandlerImpl) login(ctx context.Context) (*apisv1.UserBase, error) {
 			klog.Errorf("failed to get the system info %s", err.Error())
 		}
 		user := &model.User{
-			Email:         claims.Email,
-			Name:          strings.ToLower(claims.Sub),
+			Email: claims.Email,
+			Name: func() string {
+				sub := strings.ToLower(claims.Sub)
+				if len(sub) > datastore.PrimaryKeyMaxLength {
+					return sub[:datastore.PrimaryKeyMaxLength]
+				}
+				return sub
+			}(),
 			DexSub:        claims.Sub,
 			Alias:         claims.Name,
 			LastLoginTime: time.Now(),

--- a/pkg/server/infrastructure/datastore/datastore.go
+++ b/pkg/server/infrastructure/datastore/datastore.go
@@ -46,6 +46,9 @@ var (
 	ErrEntityInvalid = NewDBError(fmt.Errorf("entity is invalid"))
 )
 
+// PrimaryKeyMaxLength The primary key length should be limited when the datastore is kube-api
+var PrimaryKeyMaxLength = 31
+
 // DBError datastore error
 type DBError struct {
 	err error

--- a/pkg/server/interfaces/api/validate.go
+++ b/pkg/server/interfaces/api/validate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-playground/validator/v10"
 
 	"github.com/kubevela/velaux/pkg/server/domain/service"
+	"github.com/kubevela/velaux/pkg/server/infrastructure/datastore"
 )
 
 var validate = validator.New()
@@ -72,7 +73,7 @@ func ValidatePayloadType(fl validator.FieldLevel) bool {
 // ValidateName custom check name field
 func ValidateName(fl validator.FieldLevel) bool {
 	value := fl.Field().String()
-	if len(value) > 31 || len(value) < 2 {
+	if len(value) > datastore.PrimaryKeyMaxLength || len(value) < 2 {
 		return false
 	}
 	return nameRegexp.MatchString(value)


### PR DESCRIPTION
### Description of your changes

Fixes #784

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [x] Run `make reviewable`to ensure the server changes are ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
