### PR TITLE
Fix: prevent caching js when http code isn't 200

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -350,7 +350,7 @@ func enrichSwaggerObject(swo *spec.Swagger) {
 }
 
 func (s *restServer) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	staticFilters := []utils.FilterFunction{}
+	var staticFilters []utils.FilterFunction
 	if features.APIServerFeatureGate.Enabled(features.APIServerEnableCacheJSFile) {
 		staticFilters = append(staticFilters, filters.JSCache)
 	}

--- a/pkg/server/utils/filters/gzip.go
+++ b/pkg/server/utils/filters/gzip.go
@@ -32,6 +32,7 @@ func Gzip(req *http.Request, res http.ResponseWriter, chain *utils.FilterChain) 
 	if doCompress {
 		w, err := restful.NewCompressingResponseWriter(res, encoding)
 		if err != nil {
+			klog.Errorf("failed to create the compressing writer, err: %s", err.Error())
 			res.WriteHeader(http.StatusInternalServerError)
 			return
 		}

--- a/pkg/server/utils/filters/js-cache.go
+++ b/pkg/server/utils/filters/js-cache.go
@@ -42,7 +42,7 @@ func JSCache(req *http.Request, res http.ResponseWriter, chain *utils.FilterChai
 		if value, ok := jsFileCache.Get(req.URL.String()); ok {
 			if cacheData, ok := value.(*cacheData); ok {
 				if cacheData.data.Len() == 0 {
-					klog.Warningf("Cache data is empty, url: %s", req.URL.String())
+					klog.Warningf("Cache data is empty")
 					jsFileCache.Remove(req.URL.String())
 				} else {
 					cacheData.Write(res)
@@ -59,7 +59,7 @@ func JSCache(req *http.Request, res http.ResponseWriter, chain *utils.FilterChai
 		if cacheWriter.cacheData.code == http.StatusOK {
 			jsFileCache.Add(req.URL.String(), cacheWriter.cacheData)
 		} else {
-			klog.Warningf("Skip cache the js file, code: %d, url: %s", cacheWriter.cacheData.code, req.URL.String())
+			klog.Warningf("Skip cache the js file, code: %d", cacheWriter.cacheData.code)
 		}
 		return
 	}

--- a/pkg/server/utils/filters/js-cache.go
+++ b/pkg/server/utils/filters/js-cache.go
@@ -51,7 +51,11 @@ func JSCache(req *http.Request, res http.ResponseWriter, chain *utils.FilterChai
 		res.Header().Set(HeaderHitCache, "false")
 		cacheWriter := &CacheWriter{writer: res, cacheData: &cacheData{}}
 		chain.ProcessFilter(req, cacheWriter)
-		jsFileCache.Add(req.URL.String(), cacheWriter.cacheData)
+		if cacheWriter.cacheData.code == http.StatusOK {
+			jsFileCache.Add(req.URL.String(), cacheWriter.cacheData)
+		} else {
+			klog.Warningf("Skip cache the js file, code: %d, url: %s", cacheWriter.cacheData.code, req.URL.String())
+		}
 		return
 	}
 	chain.ProcessFilter(req, res)

--- a/pkg/server/utils/filters/js-cache.go
+++ b/pkg/server/utils/filters/js-cache.go
@@ -41,8 +41,13 @@ func JSCache(req *http.Request, res http.ResponseWriter, chain *utils.FilterChai
 	if matchCacheCondition(req) {
 		if value, ok := jsFileCache.Get(req.URL.String()); ok {
 			if cacheData, ok := value.(*cacheData); ok {
-				cacheData.Write(res)
-				return
+				if cacheData.data.Len() == 0 {
+					klog.Warningf("Cache data is empty, url: %s", req.URL.String())
+					jsFileCache.Remove(req.URL.String())
+				} else {
+					cacheData.Write(res)
+					return
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Description of your changes

Ref https://github.com/kubevela/velaux/issues/811

This PR prevent caching non-200 http response in JsCache. Add some logs to track the issue better.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
