### PR TITLE
Fix: Modify advanced parameters to align left

### DIFF
--- a/packages/velaux-ui/src/components/UISchema/index.less
+++ b/packages/velaux-ui/src/components/UISchema/index.less
@@ -5,7 +5,6 @@
       width: 100%;
     }
     .next-form-item-label {
-      text-align:left;
       label {
         color: #333;
         font-weight: bold;

--- a/packages/velaux-ui/src/components/UISchema/index.less
+++ b/packages/velaux-ui/src/components/UISchema/index.less
@@ -5,6 +5,7 @@
       width: 100%;
     }
     .next-form-item-label {
+      text-align:left;
       label {
         color: #333;
         font-weight: bold;

--- a/packages/velaux-ui/src/components/UISchema/index.tsx
+++ b/packages/velaux-ui/src/components/UISchema/index.tsx
@@ -969,7 +969,7 @@ class UISchema extends Component<Props, State> {
     });
     const formItemLayout = {
       labelCol: {
-        fixedSpan: 9,
+        fixedSpan: 4,
       },
       wrapperCol: {
         span: 14,


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #
In creating an application, advanced parameters should be left aligned：

![image](https://github.com/kubevela/velaux/assets/55052467/35b019b6-1aa1-4d2a-acb8-3a6797af3b5f)


I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
