### PR TITLE
Chore: adds steps for installing kubebuilder and its dependency tools to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,16 @@ e2e-server-test:
 unit-test-server:
 	go test -gcflags=all=-l -coverprofile=coverage.txt $(shell go list ./pkg/... ./cmd/...)
 
+setup-test-server:
+	curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/$(shell go env GOOS)/$(shell go env GOARCH)
+	chmod +x kubebuilder
+	sudo mv kubebuilder /usr/local/bin/
+	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	${eval OUTPUT = $(shell ${GOBIN}/setup-envtest --bin-dir /tmp use)}
+	${eval BIN_PATH=$(lastword $(subst Path:, ,${OUTPUT}))}
+	sudo mkdir -p /usr/local/kubebuilder/bin
+	sudo mv ${BIN_PATH}/* /usr/local/kubebuilder/bin
+
 build-swagger:
 	go run ./cmd/server/main.go build-swagger ./docs/apidoc/swagger.json
 

--- a/docs/contributing/velaux.md
+++ b/docs/contributing/velaux.md
@@ -78,6 +78,12 @@ make reviewable
 
 ### Test the code
 
+For testing server kubebuilder and its dependency tools are required. To install them you can use:
+
+```shell
+make setup-test-server
+```
+
 Frontend:
 
 ```shell


### PR DESCRIPTION
### Description of your changes

This PR adds `make setup-test-server` command to makefile for installing kubebuilder and its dependency tools to .
Also contribution docs is modified accordingly.

Fixes #

I have:

- [X] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
