### PR TITLE
Feat: add info about other custom triggers

### DIFF
--- a/packages/velaux-ui/src/pages/ApplicationConfig/components/TriggerList/index.less
+++ b/packages/velaux-ui/src/pages/ApplicationConfig/components/TriggerList/index.less
@@ -20,3 +20,12 @@
     cursor: pointer;
   }
 }
+
+.justify-tabs-tab.active{
+  background-color: #000 !important;
+  color: #fff !important;
+}
+
+.next-tabs-wrapped.next-tabs-top > .next-tabs-bar .next-tabs-tab{
+  border: none !important;
+}

--- a/packages/velaux-ui/src/pages/ApplicationConfig/components/TriggerList/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationConfig/components/TriggerList/index.tsx
@@ -127,7 +127,7 @@ class TriggerList extends Component<Props, State> {
       let body;
       for (let key in customTriggerBody) {
         if(key == customTriggerType) {
-          body = customTriggerBody[customTriggerType];
+          body = customTriggerBody[key];
         }
       }
       command = `curl -X POST -H 'content-type: application/json' --url ${webHookURL} -d '${JSON.stringify(body)}'`;

--- a/packages/velaux-ui/src/pages/ApplicationConfig/components/TriggerList/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationConfig/components/TriggerList/index.tsx
@@ -97,7 +97,7 @@ class TriggerList extends Component<Props, State> {
     let command = `curl -X POST -H 'content-type: application/json' --url ${webHookURL}`;
 
     if (showTrigger?.payloadType == 'custom' && component) {
-      const customTriggerBody: {[x:string]:Object} = {
+      const customTriggerBody: {[x: string]: Object} = {
         execute: {
           action: 'execute',
           upgrade: {

--- a/packages/velaux-ui/src/pages/ApplicationConfig/components/TriggerList/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationConfig/components/TriggerList/index.tsx
@@ -1,4 +1,4 @@
-import { Card, Dialog, Grid, Message } from '@alifd/next';
+import { Card, Dialog, Grid, Message , Tab } from '@alifd/next';
 import React, { Component } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 
@@ -32,7 +32,9 @@ type Props = {
 type State = {
   showTrigger?: Trigger;
   component?: ApplicationComponent;
+  customTriggerType?: string;
 };
+
 class TriggerList extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -49,6 +51,7 @@ class TriggerList extends Component<Props, State> {
     const { components } = this.props;
     this.loadComponentDetail(trigger.componentName || (components.length > 0 ? components[0].name : ''));
     this.setState({ showTrigger: trigger });
+    this.setState({ customTriggerType: 'execute' });
   };
 
   loadComponentDetail = (componentName: string) => {
@@ -79,31 +82,57 @@ class TriggerList extends Component<Props, State> {
     });
   };
 
+  handleCustomTriggerTab = (token: string) => {
+    this.setState({ customTriggerType: token });
+  }
+
   render() {
     const { Row, Col } = Grid;
     const { triggers, applicationDetail } = this.props;
 
-    const { showTrigger, component } = this.state;
+    const { showTrigger, component, customTriggerType } = this.state;
 
     const domain = `${window.location.protocol}//${window.location.host}`;
     const webHookURL = `${domain}/api/v1/webhook/${showTrigger?.token}`;
     let command = `curl -X POST -H 'content-type: application/json' --url ${webHookURL}`;
 
     if (showTrigger?.payloadType == 'custom' && component) {
-      const body = {
-        upgrade: {
-          [component.name]: {
-            image: component.properties && component.properties.image,
+      const customTriggerBody = {
+        execute: {
+          action: 'execute',
+          upgrade: {
+            [component.name]: {
+              image: component.properties && component.properties.image,
+            },
+          },
+          codeInfo: {
+            commit: '',
+            branch: '',
+            user: '',
           },
         },
-        codeInfo: {
-          commit: '',
-          branch: '',
-          user: '',
+        approve:{
+          action: 'approve',
+          step : 'suspend'
         },
-      };
+        terminate:{
+          action: 'terminate',
+          step : 'suspend'
+        },
+        rollback :{
+          action: 'rollback',
+          step : 'suspend'
+        }
+      }
+      let body;
+      for (let key in customTriggerBody) {
+        if(key == customTriggerType) {
+          body = customTriggerBody[customTriggerType];
+        }
+      }
       command = `curl -X POST -H 'content-type: application/json' --url ${webHookURL} -d '${JSON.stringify(body)}'`;
     }
+
     const copy = (
       <span style={{ lineHeight: '16px', marginLeft: '8px' }}>
         <svg
@@ -129,6 +158,7 @@ class TriggerList extends Component<Props, State> {
         </svg>
       </span>
     );
+    const customTriggerTypes = ['execute', 'approve', 'terminate', 'rollback'];
     const projectName = applicationDetail && applicationDetail.project?.name;
     return (
       <div className="list-warper">
@@ -270,23 +300,30 @@ class TriggerList extends Component<Props, State> {
               </Col>
             </Row>
             <Row>
-              <Col span={24} className="curlCode">
-                <h4>
-                  <Translation>Curl Command</Translation>
-                  <CopyToClipboard
-                    onCopy={() => {
-                      Message.success('Copy successfully');
-                    }}
-                    text={command}
-                  >
-                    {copy}
-                  </CopyToClipboard>
-                </h4>
-                <code>{command}</code>
-                <span>
-                  <Translation>Please set the properties that need to be changed, such as `image`</Translation>
-                </span>
-              </Col>
+              <Tab size="small" shape="capsule">
+              {(customTriggerTypes).map((item: string) => (
+                  <Tab.Item onClick={()=>{this.handleCustomTriggerTab(item)}} key={item} title={item}>
+                  <Col span={24} className="curlCode">
+                  <h4>
+                    <Translation>Curl Command</Translation>
+                    <CopyToClipboard
+                      onCopy={() => {
+                        Message.success('Copy successfully');
+                      }}
+                      text={command}
+                    >
+                      {copy}
+                    </CopyToClipboard>
+                  </h4>
+                  <code>{command}</code>
+                  <span>
+                    <Translation>Please set the properties that need to be changed, such as `image`, `step`.</Translation>
+                    <Message type='notice'> If action is not provided then it will by default execute the workflow.</Message>
+                  </span>
+                </Col>
+                  </Tab.Item>
+              ))}
+              </Tab>
             </Row>
           </Dialog>
         </If>

--- a/packages/velaux-ui/src/pages/ApplicationConfig/components/TriggerList/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationConfig/components/TriggerList/index.tsx
@@ -124,12 +124,7 @@ class TriggerList extends Component<Props, State> {
           step : 'suspend'
         }
       }
-      let body;
-      for (let key in customTriggerBody) {
-        if(key == customTriggerType) {
-          body = customTriggerBody[key];
-        }
-      }
+      let body =  customTriggerType ? customTriggerBody[customTriggerType] : " ";
       command = `curl -X POST -H 'content-type: application/json' --url ${webHookURL} -d '${JSON.stringify(body)}'`;
     }
 
@@ -299,12 +294,7 @@ class TriggerList extends Component<Props, State> {
                 />
               </Col>
             </Row>
-            <Row>
-              <Tab size="small" shape="capsule">
-              {(customTriggerTypes).map((item: string) => (
-                  <Tab.Item onClick={()=>{this.handleCustomTriggerTab(item)}} key={item} title={item}>
-                  <Col span={24} className="curlCode">
-                  <h4>
+            <h4>
                     <Translation>Curl Command</Translation>
                     <CopyToClipboard
                       onCopy={() => {
@@ -315,6 +305,11 @@ class TriggerList extends Component<Props, State> {
                       {copy}
                     </CopyToClipboard>
                   </h4>
+            <Row>
+              <Tab size="small" shape="wrapped">
+              {(customTriggerTypes).map((item: string) => (
+                  <Tab.Item className="justify-tabs-tab" onClick={()=>{this.handleCustomTriggerTab(item)}} key={item} title={item}>
+                  <Col span={24} className="curlCode">
                   <code>{command}</code>
                   <span>
                     <Translation>Please set the properties that need to be changed, such as `image`, `step`.</Translation>

--- a/packages/velaux-ui/src/pages/ApplicationConfig/components/TriggerList/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationConfig/components/TriggerList/index.tsx
@@ -97,7 +97,7 @@ class TriggerList extends Component<Props, State> {
     let command = `curl -X POST -H 'content-type: application/json' --url ${webHookURL}`;
 
     if (showTrigger?.payloadType == 'custom' && component) {
-      const customTriggerBody = {
+      const customTriggerBody: {[x:string]:Object} = {
         execute: {
           action: 'execute',
           upgrade: {


### PR DESCRIPTION
### Description of your changes

This PR adds curl commands for all types of custom triggers.


https://github.com/kubevela/velaux/assets/80708727/ed8e0c03-58b5-4c54-a4ab-b8b15577690c


<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


Fixes #834 

I have:

- [X] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [X] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
