### PR TITLE
Fix: customized uiSchema can't show properly

### DIFF
--- a/packages/velaux-ui/src/components/UISchema/index.tsx
+++ b/packages/velaux-ui/src/components/UISchema/index.tsx
@@ -192,9 +192,6 @@ class UISchema extends Component<Props, State> {
       if (condition.action == 'enable' || !condition.action) {
         enableConditionCount += 1;
       }
-      if (value == undefined) {
-        return;
-      }
       switch (condition.op) {
         case 'in':
           if (Array.isArray(condition.value) && condition.value.includes(value)) {
@@ -976,7 +973,7 @@ class UISchema extends Component<Props, State> {
     };
 
     const showAdvancedButton = couldBeDisabledParamCount != couldShowParamCount || requiredParamCount === 0;
-    return (
+    return ( 
       <Form field={this.form} className="ui-schema-container">
         <If condition={disableRenderRow}>{items}</If>
         <If condition={!disableRenderRow}>

--- a/packages/velaux-ui/src/extends/Group/index.tsx
+++ b/packages/velaux-ui/src/extends/Group/index.tsx
@@ -57,7 +57,7 @@ class Group extends React.Component<Props, State> {
 
   initSwitchState = () => {
     const { jsonKey = '', propertyValue = {}, alwaysShow = false, required, closed, initClose } = this.props;
-    const findKey = Object.keys(propertyValue).find((item) => item === jsonKey);
+    const findKey = propertyValue && Object.keys(propertyValue).find((item) => item === jsonKey);
     if (findKey || alwaysShow) {
       this.setState({ enable: true, closed: false || initClose, checked: true });
     } else if (required) {


### PR DESCRIPTION
### Description of your changes
the two group of properties ,as show in the picture, can't coexist
<img width="789" alt="image" src="https://github.com/kubevela/velaux/assets/10116106/ade10a0c-b2c5-4fc2-b4f2-494521ce250a">
otherwise it will has an error when deploy app
<img width="617" alt="image" src="https://github.com/kubevela/velaux/assets/10116106/826b8f02-d288-43e2-812f-8d0a838199f6">
So, we customized the uiSchema as follows
<img width="1302" alt="image" src="https://github.com/kubevela/velaux/assets/10116106/2e0e1cc2-ddf4-45be-b845-27e1a6f936a7">
But the customized uiSchema can't show properly

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
