### PR TITLE
Fix: applied default cluster to created target

### DIFF
--- a/pkg/server/domain/service/target.go
+++ b/pkg/server/domain/service/target.go
@@ -145,10 +145,10 @@ func (dt *targetServiceImpl) CreateTarget(ctx context.Context, req apisv1.Create
 	if err := dt.Store.Get(ctx, &project); err != nil {
 		return nil, bcode.ErrProjectIsNotExist
 	}
-	target := convertCreateReqToTargetModel(req)
 	if req.Cluster == nil {
 		req.Cluster = &apisv1.ClusterTarget{ClusterName: multicluster.ClusterLocalName, Namespace: req.Name}
 	}
+	target := convertCreateReqToTargetModel(req)
 	createTargetCtx := utils.WithProject(ctx, "")
 	if err := repository.CreateTargetNamespace(createTargetCtx, dt.K8sClient, req.Cluster.ClusterName, req.Cluster.Namespace, req.Name); err != nil {
 		return nil, err


### PR DESCRIPTION
### Description of your changes


In CreateTarget, a default cluster should be created if cluster is not speicified in the request. However, cluster is only applied to the _request_ variable, not the actual created _target_ . With this fix, the created _target_ would have default _cluster_


Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
