### PR TITLE
Fix: additionalPropertis in openapi schema converted to uischema wrongly

### DIFF
--- a/pkg/server/domain/service/definition.go
+++ b/pkg/server/domain/service/definition.go
@@ -496,7 +496,7 @@ func renderUIParameter(key, label string, property *openapi3.SchemaRef, required
 		parameter.SubParameters = renderDefaultUISchema(property.Value)
 	}
 	var ap = property.Value.AdditionalProperties
-	if ap.Has != nil && *ap.Has && ap.Schema != nil && ap.Schema.Value != nil {
+	if ap.Schema != nil && ap.Schema.Value != nil {
 		value := ap.Schema.Value
 		parameter.SubParameters = renderDefaultUISchema(value)
 		var enable = true


### PR DESCRIPTION
### Description of your changes

The meaning of additionalProperties.has is wrongly used. Then default uischema of gateway is wrongly generated.

Ref: https://swagger.io/docs/specification/data-models/dictionaries/

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes https://github.com/kubevela/kubevela/issues/6165

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [x] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
