### PR TITLE
Fix: incorrect API response mark

### DIFF
--- a/pkg/server/interfaces/api/application.go
+++ b/pkg/server/interfaces/api/application.go
@@ -466,7 +466,7 @@ func (c *application) GetWebServiceRoute() *restful.WebService {
 		Param(ws.QueryParameter("page", "query the page number").DataType("integer")).
 		Param(ws.QueryParameter("pageSize", "query the page size number").DataType("integer")).
 		Returns(200, "OK", apis.ListWorkflowRecordsResponse{}).
-		Writes(apis.ListWorkflowRecordsResponse{}).Do(returns200, returns500))
+		Writes(apis.ListWorkflowRecordsResponse{}).Do(returns500))
 
 	ws.Route(ws.GET("/{appName}/workflows").To(c.WorkflowAPI.listApplicationWorkflows).
 		Doc("list application workflow").
@@ -475,7 +475,7 @@ func (c *application) GetWebServiceRoute() *restful.WebService {
 		Param(ws.PathParameter("appName", "identifier of the application.").DataType("string").Required(true)).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Returns(200, "OK", apis.ListWorkflowResponse{}).
-		Writes(apis.ListWorkflowResponse{}).Do(returns200, returns500))
+		Writes(apis.ListWorkflowResponse{}).Do(returns500))
 
 	ws.Route(ws.POST("/{appName}/workflows").To(c.WorkflowAPI.createOrUpdateApplicationWorkflow).
 		Doc("create application workflow").
@@ -486,7 +486,7 @@ func (c *application) GetWebServiceRoute() *restful.WebService {
 		Param(ws.PathParameter("appName", "identifier of the application.").DataType("string").Required(true)).
 		Returns(200, "create success", apis.DetailWorkflowResponse{}).
 		Returns(400, "create failure", bcode.Bcode{}).
-		Writes(apis.DetailWorkflowResponse{}).Do(returns200, returns500))
+		Writes(apis.DetailWorkflowResponse{}).Do(returns500))
 
 	ws.Route(ws.GET("/{appName}/workflows/{workflowName}").To(c.WorkflowAPI.detailWorkflow).
 		Doc("detail application workflow").
@@ -498,7 +498,7 @@ func (c *application) GetWebServiceRoute() *restful.WebService {
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Filter(c.WorkflowAPI.workflowCheckFilter).
 		Returns(200, "create success", apis.DetailWorkflowResponse{}).
-		Writes(apis.DetailWorkflowResponse{}).Do(returns200, returns500))
+		Writes(apis.DetailWorkflowResponse{}).Do(returns500))
 
 	ws.Route(ws.PUT("/{appName}/workflows/{workflowName}").To(c.WorkflowAPI.updateWorkflow).
 		Doc("update application workflow config").
@@ -510,7 +510,7 @@ func (c *application) GetWebServiceRoute() *restful.WebService {
 		Param(ws.PathParameter("workflowName", "identifier of the workflow").DataType("string")).
 		Reads(apis.UpdateWorkflowRequest{}).
 		Returns(200, "OK", apis.DetailWorkflowResponse{}).
-		Writes(apis.DetailWorkflowResponse{}).Do(returns200, returns500))
+		Writes(apis.DetailWorkflowResponse{}).Do(returns500))
 
 	ws.Route(ws.DELETE("/{appName}/workflows/{workflowName}").To(c.WorkflowAPI.deleteWorkflow).
 		Doc("deletet workflow").
@@ -521,7 +521,7 @@ func (c *application) GetWebServiceRoute() *restful.WebService {
 		Param(ws.PathParameter("appName", "identifier of the application.").DataType("string").Required(true)).
 		Param(ws.PathParameter("workflowName", "identifier of the workflow").DataType("string")).
 		Returns(200, "OK", apis.EmptyResponse{}).
-		Writes(apis.EmptyResponse{}).Do(returns200, returns500))
+		Writes(apis.EmptyResponse{}).Do(returns500))
 
 	ws.Route(ws.GET("/{appName}/workflows/{workflowName}/records").To(c.WorkflowAPI.listWorkflowRecords).
 		Doc("query application workflow execution record").
@@ -534,7 +534,7 @@ func (c *application) GetWebServiceRoute() *restful.WebService {
 		Param(ws.QueryParameter("page", "query the page number").DataType("integer")).
 		Param(ws.QueryParameter("pageSize", "query the page size number").DataType("integer")).
 		Returns(200, "OK", apis.ListWorkflowRecordsResponse{}).
-		Writes(apis.ListWorkflowRecordsResponse{}).Do(returns200, returns500))
+		Writes(apis.ListWorkflowRecordsResponse{}).Do(returns500))
 
 	ws.Route(ws.GET("/{appName}/workflows/{workflowName}/records/{record}").To(c.WorkflowAPI.detailWorkflowRecord).
 		Doc("query application workflow execution record detail").
@@ -546,7 +546,7 @@ func (c *application) GetWebServiceRoute() *restful.WebService {
 		Filter(c.appCheckFilter).
 		Filter(c.WorkflowAPI.workflowCheckFilter).
 		Returns(200, "OK", apis.DetailWorkflowRecordResponse{}).
-		Writes(apis.DetailWorkflowRecordResponse{}).Do(returns200, returns500))
+		Writes(apis.DetailWorkflowRecordResponse{}).Do(returns500))
 
 	ws.Route(ws.GET("/{appName}/workflows/{workflowName}/records/{record}/resume").To(c.WorkflowAPI.resumeWorkflowRecord).
 		Doc("resume suspend workflow record").
@@ -684,16 +684,19 @@ func (c *application) createApplication(req *restful.Request, res *restful.Respo
 	// Verify the validity of parameters
 	var createReq apis.CreateApplicationRequest
 	if err := req.ReadEntity(&createReq); err != nil {
+		klog.Info("param err ", err)
 		bcode.ReturnError(req, res, err)
 		return
 	}
 	if err := validate.Struct(&createReq); err != nil {
+		klog.Info("validate struct err ", err)
 		bcode.ReturnError(req, res, err)
 		return
 	}
 	// Call the domain layer code
 	appBase, err := c.ApplicationService.CreateApplication(req.Request.Context(), createReq)
 	if err != nil {
+		klog.Info("Failure: ", err.Error())
 		klog.Errorf("create application failure %s", err.Error())
 		bcode.ReturnError(req, res, err)
 		return
@@ -1043,19 +1046,23 @@ func (c *application) updateApplication(req *restful.Request, res *restful.Respo
 	// Verify the validity of parameters
 	var updateReq apis.UpdateApplicationRequest
 	if err := req.ReadEntity(&updateReq); err != nil {
+		klog.Info("read entity err", err)
 		bcode.ReturnError(req, res, err)
 		return
 	}
 	if err := validate.Struct(&updateReq); err != nil {
+		klog.Info("Validate err", err)
 		bcode.ReturnError(req, res, err)
 		return
 	}
 	base, err := c.ApplicationService.UpdateApplication(req.Request.Context(), app, updateReq)
 	if err != nil {
+		klog.Info("update app err", err)
 		bcode.ReturnError(req, res, err)
 		return
 	}
 	if err := res.WriteEntity(base); err != nil {
+		klog.Info("write entity err", err)
 		bcode.ReturnError(req, res, err)
 		return
 	}

--- a/pkg/server/interfaces/api/application.go
+++ b/pkg/server/interfaces/api/application.go
@@ -520,8 +520,7 @@ func (c *application) GetWebServiceRoute() *restful.WebService {
 		Filter(c.WorkflowAPI.workflowCheckFilter).
 		Param(ws.PathParameter("appName", "identifier of the application.").DataType("string").Required(true)).
 		Param(ws.PathParameter("workflowName", "identifier of the workflow").DataType("string")).
-		Returns(200, "OK", apis.EmptyResponse{}).
-		Writes(apis.EmptyResponse{}).Do(returns500))
+		Writes(apis.EmptyResponse{}).Do(returns200, returns500))
 
 	ws.Route(ws.GET("/{appName}/workflows/{workflowName}/records").To(c.WorkflowAPI.listWorkflowRecords).
 		Doc("query application workflow execution record").

--- a/pkg/server/interfaces/api/application.go
+++ b/pkg/server/interfaces/api/application.go
@@ -1046,23 +1046,19 @@ func (c *application) updateApplication(req *restful.Request, res *restful.Respo
 	// Verify the validity of parameters
 	var updateReq apis.UpdateApplicationRequest
 	if err := req.ReadEntity(&updateReq); err != nil {
-		klog.Info("read entity err", err)
 		bcode.ReturnError(req, res, err)
 		return
 	}
 	if err := validate.Struct(&updateReq); err != nil {
-		klog.Info("Validate err", err)
 		bcode.ReturnError(req, res, err)
 		return
 	}
 	base, err := c.ApplicationService.UpdateApplication(req.Request.Context(), app, updateReq)
 	if err != nil {
-		klog.Info("update app err", err)
 		bcode.ReturnError(req, res, err)
 		return
 	}
 	if err := res.WriteEntity(base); err != nil {
-		klog.Info("write entity err", err)
 		bcode.ReturnError(req, res, err)
 		return
 	}

--- a/pkg/server/interfaces/api/cloudshell.go
+++ b/pkg/server/interfaces/api/cloudshell.go
@@ -65,9 +65,8 @@ func (c *CloudShell) GetWebServiceRoute() *restful.WebService {
 		Doc("destroy the user's cloud shell environment").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Filter(c.RbacService.CheckPerm("cloudshell", "delete")).
-		Returns(200, "OK", apis.EmptyResponse{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
-		Writes(apis.EmptyResponse{}).Do(returns500))
+		Writes(apis.EmptyResponse{}).Do(returns200, returns500))
 
 	ws.Filter(authCheckFilter)
 	return ws
@@ -128,9 +127,8 @@ func (c *CloudShellView) GetWebServiceRoute() *restful.WebService {
 		Doc("prepare the user's cloud shell environment").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Filter(c.RbacService.CheckPerm("cloudshell", "create")).
-		Returns(200, "OK", apis.EmptyResponse{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
-		Writes(apis.EmptyResponse{}).Do(returns500))
+		Writes(apis.EmptyResponse{}).Do(returns200, returns500))
 
 	ws.Route(ws.GET("/{subpath:*}").To(c.proxy).
 		Doc("prepare the user's cloud shell environment").
@@ -138,9 +136,8 @@ func (c *CloudShellView) GetWebServiceRoute() *restful.WebService {
 		Operation("proxyPath").
 		Param(ws.PathParameter("subpath", "subpath").DataType("string")).
 		Filter(c.RbacService.CheckPerm("cloudshell", "create")).
-		Returns(200, "OK", apis.EmptyResponse{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
-		Writes(apis.EmptyResponse{}).Do(returns500))
+		Writes(apis.EmptyResponse{}).Do(returns200, returns500))
 
 	ws.Filter(authCheckFilter)
 	return ws

--- a/pkg/server/interfaces/api/cloudshell.go
+++ b/pkg/server/interfaces/api/cloudshell.go
@@ -59,7 +59,7 @@ func (c *CloudShell) GetWebServiceRoute() *restful.WebService {
 		Filter(c.RbacService.CheckPerm("cloudshell", "create")).
 		Returns(200, "OK", apis.CloudShellPrepareResponse{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
-		Writes(apis.CloudShellPrepareResponse{}).Do(returns200, returns500))
+		Writes(apis.CloudShellPrepareResponse{}).Do(returns500))
 
 	ws.Route(ws.DELETE("/").To(c.destroyCloudShell).
 		Doc("destroy the user's cloud shell environment").
@@ -67,7 +67,7 @@ func (c *CloudShell) GetWebServiceRoute() *restful.WebService {
 		Filter(c.RbacService.CheckPerm("cloudshell", "delete")).
 		Returns(200, "OK", apis.EmptyResponse{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
-		Writes(apis.EmptyResponse{}).Do(returns200, returns500))
+		Writes(apis.EmptyResponse{}).Do(returns500))
 
 	ws.Filter(authCheckFilter)
 	return ws
@@ -130,7 +130,7 @@ func (c *CloudShellView) GetWebServiceRoute() *restful.WebService {
 		Filter(c.RbacService.CheckPerm("cloudshell", "create")).
 		Returns(200, "OK", apis.EmptyResponse{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
-		Writes(apis.EmptyResponse{}).Do(returns200, returns500))
+		Writes(apis.EmptyResponse{}).Do(returns500))
 
 	ws.Route(ws.GET("/{subpath:*}").To(c.proxy).
 		Doc("prepare the user's cloud shell environment").
@@ -140,7 +140,7 @@ func (c *CloudShellView) GetWebServiceRoute() *restful.WebService {
 		Filter(c.RbacService.CheckPerm("cloudshell", "create")).
 		Returns(200, "OK", apis.EmptyResponse{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
-		Writes(apis.EmptyResponse{}).Do(returns200, returns500))
+		Writes(apis.EmptyResponse{}).Do(returns500))
 
 	ws.Filter(authCheckFilter)
 	return ws

--- a/pkg/server/interfaces/api/cluster.go
+++ b/pkg/server/interfaces/api/cluster.go
@@ -56,7 +56,7 @@ func (c *Cluster) GetWebServiceRoute() *restful.WebService {
 		Param(ws.QueryParameter("pageSize", "PageSize for paging").DataType("integer").DefaultValue("20")).
 		Returns(200, "OK", apis.ListClusterResponse{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
-		Writes(apis.ListClusterResponse{}).Do(returns200, returns500))
+		Writes(apis.ListClusterResponse{}).Do(returns500))
 
 	ws.Route(ws.POST("/").To(c.createKubeCluster).
 		Doc("create cluster").

--- a/pkg/server/interfaces/api/definition.go
+++ b/pkg/server/interfaces/api/definition.go
@@ -54,7 +54,7 @@ func (d *definition) GetWebServiceRoute() *restful.WebService {
 		Param(ws.QueryParameter("ownerAddon", "query by which addon created the definition").DataType("string")).
 		Param(ws.QueryParameter("scope", "query by the specified scope like WorkflowRun or Application").DataType("string")).
 		Returns(200, "OK", apis.ListDefinitionResponse{}).
-		Writes(apis.ListDefinitionResponse{}).Do(returns200, returns500))
+		Writes(apis.ListDefinitionResponse{}).Do(returns500))
 
 	ws.Route(ws.GET("/{definitionName}").To(d.detailDefinition).
 		Doc("Detail a definition").
@@ -63,7 +63,7 @@ func (d *definition) GetWebServiceRoute() *restful.WebService {
 		Param(ws.QueryParameter("type", "query the definition type").DataType("string")).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Returns(200, "create successfully", apis.DetailDefinitionResponse{}).
-		Writes(apis.DetailDefinitionResponse{}).Do(returns200, returns500))
+		Writes(apis.DetailDefinitionResponse{}).Do(returns500))
 
 	ws.Route(ws.PUT("/{definitionName}/uischema").To(d.updateUISchema).
 		Doc("Update the UI schema for a definition").
@@ -72,7 +72,7 @@ func (d *definition) GetWebServiceRoute() *restful.WebService {
 		Param(ws.PathParameter("definitionName", "identifier of the definition").DataType("string").Required(true)).
 		Reads(apis.UpdateUISchemaRequest{}).
 		Returns(200, "update successfully", schema.UISchema{}).
-		Writes(apis.DetailDefinitionResponse{}).Do(returns200, returns500))
+		Writes(apis.DetailDefinitionResponse{}).Do(returns500))
 
 	ws.Route(ws.PUT("/{definitionName}/status").To(d.updateDefinitionStatus).
 		Doc("Update the status for a definition").
@@ -81,7 +81,7 @@ func (d *definition) GetWebServiceRoute() *restful.WebService {
 		Param(ws.PathParameter("definitionName", "identifier of the definition").DataType("string").Required(true)).
 		Reads(apis.UpdateDefinitionStatusRequest{}).
 		Returns(200, "update successfully", schema.UISchema{}).
-		Writes(apis.DetailDefinitionResponse{}).Do(returns200, returns500))
+		Writes(apis.DetailDefinitionResponse{}).Do(returns500))
 
 	ws.Filter(authCheckFilter)
 	return ws

--- a/pkg/server/interfaces/api/plugin.go
+++ b/pkg/server/interfaces/api/plugin.go
@@ -112,6 +112,7 @@ func (p *ManagePlugin) GetWebServiceRoute() *restful.WebService {
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Reads(apis.InstallPluginRequest{}).
 		Filter(p.RBACService.CheckPerm("managePlugin", "enable")).
+		Param(ws.PathParameter("pluginId", "identifier of the plugin.").DataType("string")).
 		Returns(200, "OK", apis.ManagedPluginDTO{}).
 		Writes(apis.PluginDTO{}).Do(returns500))
 
@@ -119,6 +120,7 @@ func (p *ManagePlugin) GetWebServiceRoute() *restful.WebService {
 		Doc("Uninstall one specific plugin").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Filter(p.RBACService.CheckPerm("managePlugin", "enable")).
+		Param(ws.PathParameter("pluginId", "identifier of the plugin.").DataType("string")).
 		Returns(200, "OK", struct{}{}).
 		Writes(apis.PluginDTO{}).Do(returns500))
 

--- a/pkg/server/interfaces/api/plugin.go
+++ b/pkg/server/interfaces/api/plugin.go
@@ -61,13 +61,14 @@ func (p *Plugin) GetWebServiceRoute() *restful.WebService {
 		Doc("List the enabled plugins").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Returns(200, "OK", apis.ListPluginResponse{}).
-		Writes(apis.ListPluginResponse{}).Do(returns200, returns500))
+		Writes(apis.ListPluginResponse{}).Do(returns500))
 
 	ws.Route(ws.GET("/{pluginId}").To(p.detailPlugin).
 		Doc("Detail an installed plugin").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Param(ws.PathParameter("pluginId", "identifier of the plugin.").DataType("string")).
 		Returns(200, "OK", apis.PluginDTO{}).
-		Writes(apis.PluginDTO{}).Do(returns200, returns500))
+		Writes(apis.PluginDTO{}).Do(returns500))
 
 	ws.Filter(authCheckFilter)
 	return ws
@@ -88,21 +89,23 @@ func (p *ManagePlugin) GetWebServiceRoute() *restful.WebService {
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Filter(p.RBACService.CheckPerm("managePlugin", "list")).
 		Returns(200, "OK", apis.ListPluginResponse{}).
-		Writes(apis.ListManagedPluginResponse{}).Do(returns200, returns500))
+		Writes(apis.ListPluginResponse{}).Do(returns500))
 
 	ws.Route(ws.GET("/{pluginId}").To(p.detailPlugin).
 		Doc("Detail an installed plugin").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Filter(p.RBACService.CheckPerm("managePlugin", "detail")).
+		Param(ws.PathParameter("pluginId", "identifier of the plugin.").DataType("string")).
 		Returns(200, "OK", apis.ManagedPluginDTO{}).
-		Writes(apis.PluginDTO{}).Do(returns200, returns500))
+		Writes(apis.PluginDTO{}).Do(returns500))
 
 	ws.Route(ws.POST("/{pluginId}/setting").To(p.pluginSetting).
 		Doc("Set an installed plugin").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Filter(p.RBACService.CheckPerm("managePlugin", "update")).
+		Param(ws.PathParameter("pluginId", "identifier of the plugin.").DataType("string")).
 		Returns(200, "OK", apis.ManagedPluginDTO{}).
-		Writes(apis.PluginDTO{}).Do(returns200, returns500))
+		Writes(apis.PluginDTO{}).Do(returns500))
 
 	ws.Route(ws.POST("/{pluginId}/install").To(p.installPlugin).
 		Doc("Install one specific plugin").
@@ -110,29 +113,31 @@ func (p *ManagePlugin) GetWebServiceRoute() *restful.WebService {
 		Reads(apis.InstallPluginRequest{}).
 		Filter(p.RBACService.CheckPerm("managePlugin", "enable")).
 		Returns(200, "OK", apis.ManagedPluginDTO{}).
-		Writes(apis.PluginDTO{}).Do(returns200, returns500))
+		Writes(apis.PluginDTO{}).Do(returns500))
 
 	ws.Route(ws.POST("/{pluginId}/uninstall").To(p.uninstallPlugin).
 		Doc("Uninstall one specific plugin").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Filter(p.RBACService.CheckPerm("managePlugin", "enable")).
 		Returns(200, "OK", struct{}{}).
-		Writes(apis.PluginDTO{}).Do(returns200, returns500))
+		Writes(apis.PluginDTO{}).Do(returns500))
 
 	ws.Route(ws.POST("/{pluginId}/enable").To(p.enablePlugin).
 		Doc("Enable an installed plugin").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Reads(apis.PluginEnableRequest{}).
 		Filter(p.RBACService.CheckPerm("managePlugin", "enable")).
+		Param(ws.PathParameter("pluginId", "identifier of the plugin.").DataType("string")).
 		Returns(200, "OK", apis.ManagedPluginDTO{}).
-		Writes(apis.PluginDTO{}).Do(returns200, returns500))
+		Writes(apis.PluginDTO{}).Do(returns500))
 
 	ws.Route(ws.POST("/{pluginId}/disable").To(p.disablePlugin).
 		Doc("Disable an installed plugin").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Filter(p.RBACService.CheckPerm("managePlugin", "enable")).
+		Param(ws.PathParameter("pluginId", "identifier of the plugin.").DataType("string")).
 		Returns(200, "OK", apis.ManagedPluginDTO{}).
-		Writes(apis.PluginDTO{}).Do(returns200, returns500))
+		Writes(apis.PluginDTO{}).Do(returns500))
 
 	ws.Filter(authCheckFilter)
 	return ws
@@ -205,6 +210,7 @@ func (p *ManagePlugin) uninstallPlugin(req *restful.Request, res *restful.Respon
 }
 
 func (p *ManagePlugin) detailPlugin(req *restful.Request, res *restful.Response) {
+
 	plugin, err := p.PluginService.DetailInstalledPlugin(req.Request.Context(), req.PathParameter("pluginId"))
 	if err != nil {
 		bcode.ReturnError(req, res, err)

--- a/pkg/server/interfaces/api/target.go
+++ b/pkg/server/interfaces/api/target.go
@@ -64,7 +64,7 @@ func (dt *Target) GetWebServiceRoute() *restful.WebService {
 		Param(ws.QueryParameter("pageSize", "PageSize for paging").DataType("integer")).
 		Param(ws.QueryParameter("project", "list targets by project name").DataType("string")).
 		Returns(200, "OK", apis.ListTargetResponse{}).
-		Writes(apis.ListTargetResponse{}).Do(returns200, returns500))
+		Writes(apis.ListTargetResponse{}).Do(returns500))
 
 	ws.Route(ws.POST("/").To(dt.createTarget).
 		Doc("create Target").
@@ -73,7 +73,7 @@ func (dt *Target) GetWebServiceRoute() *restful.WebService {
 		Filter(dt.RbacService.CheckPerm("target", "create")).
 		Returns(200, "create success", apis.DetailTargetResponse{}).
 		Returns(400, "create failure", bcode.Bcode{}).
-		Writes(apis.DetailTargetResponse{}).Do(returns200, returns500))
+		Writes(apis.DetailTargetResponse{}).Do(returns500))
 
 	ws.Route(ws.GET("/{targetName}").To(dt.detailTarget).
 		Doc("detail Target").
@@ -82,7 +82,7 @@ func (dt *Target) GetWebServiceRoute() *restful.WebService {
 		Filter(dt.targetCheckFilter).
 		Filter(dt.RbacService.CheckPerm("target", "detail")).
 		Returns(200, "create success", apis.DetailTargetResponse{}).
-		Writes(apis.DetailTargetResponse{}).Do(returns200, returns500))
+		Writes(apis.DetailTargetResponse{}).Do(returns500))
 
 	ws.Route(ws.PUT("/{targetName}").To(dt.updateTarget).
 		Doc("update application Target config").
@@ -92,7 +92,7 @@ func (dt *Target) GetWebServiceRoute() *restful.WebService {
 		Reads(apis.UpdateTargetRequest{}).
 		Filter(dt.RbacService.CheckPerm("target", "update")).
 		Returns(200, "OK", apis.DetailTargetResponse{}).
-		Writes(apis.DetailTargetResponse{}).Do(returns200, returns500))
+		Writes(apis.DetailTargetResponse{}).Do(returns500))
 
 	ws.Route(ws.DELETE("/{targetName}").To(dt.deleteTarget).
 		Doc("deletet Target").
@@ -101,7 +101,7 @@ func (dt *Target) GetWebServiceRoute() *restful.WebService {
 		Filter(dt.RbacService.CheckPerm("target", "delete")).
 		Param(ws.PathParameter("targetName", "identifier of the Target").DataType("string")).
 		Returns(200, "OK", apis.EmptyResponse{}).
-		Writes(apis.EmptyResponse{}).Do(returns200, returns500))
+		Writes(apis.EmptyResponse{}).Do(returns500))
 
 	ws.Filter(authCheckFilter)
 	return ws

--- a/pkg/server/interfaces/api/target.go
+++ b/pkg/server/interfaces/api/target.go
@@ -100,8 +100,7 @@ func (dt *Target) GetWebServiceRoute() *restful.WebService {
 		Filter(dt.targetCheckFilter).
 		Filter(dt.RbacService.CheckPerm("target", "delete")).
 		Param(ws.PathParameter("targetName", "identifier of the Target").DataType("string")).
-		Returns(200, "OK", apis.EmptyResponse{}).
-		Writes(apis.EmptyResponse{}).Do(returns500))
+		Writes(apis.EmptyResponse{}).Do(returns200, returns500))
 
 	ws.Filter(authCheckFilter)
 	return ws


### PR DESCRIPTION
### Description of your changes

Some API have returns200 in the response, which would overwrite the desired API response format with a SimpleResponse object, which is a bug on the server side. This MR removes the `returns200` field so that each API response will respond data in the wanted format

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
