### PR TITLE
Fix: fail to get global helm config secret

### DIFF
--- a/pkg/server/domain/service/config.go
+++ b/pkg/server/domain/service/config.go
@@ -48,6 +48,17 @@ type ConfigService interface {
 	ListConfigDistributions(ctx context.Context, project string) ([]*config.Distribution, error)
 }
 
+var (
+	// GlobalConfigNamespace is the namespace for global config, global config should be seen by all projects
+	GlobalConfigNamespace = types.DefaultKubeVelaNS
+	// NoProject is the project name to pass when query global config
+	NoProject = ""
+)
+
+func isGlobal(project string) bool {
+	return project == NoProject
+}
+
 // NewConfigService returns a config use case
 func NewConfigService() ConfigService {
 	return &configServiceImpl{}
@@ -62,8 +73,8 @@ type configServiceImpl struct {
 
 // ListTemplates list the config templates
 func (u *configServiceImpl) ListTemplates(ctx context.Context, project, scope string) ([]*apis.ConfigTemplate, error) {
-	listCtx := utils.WithProject(ctx, "")
-	queryTemplates, err := u.Factory.ListTemplates(listCtx, types.DefaultKubeVelaNS, scope)
+	listCtx := utils.WithProject(ctx, NoProject)
+	queryTemplates, err := u.Factory.ListTemplates(listCtx, GlobalConfigNamespace, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -99,9 +110,9 @@ func (u *configServiceImpl) ListTemplates(ctx context.Context, project, scope st
 // GetTemplate detail a template
 func (u *configServiceImpl) GetTemplate(ctx context.Context, tem config.NamespacedName) (*apis.ConfigTemplateDetail, error) {
 	if tem.Namespace == "" {
-		tem.Namespace = types.DefaultKubeVelaNS
+		tem.Namespace = GlobalConfigNamespace
 	}
-	getCtx := utils.WithProject(ctx, "")
+	getCtx := utils.WithProject(ctx, NoProject)
 	template, err := u.Factory.LoadTemplate(getCtx, tem.Name, tem.Namespace)
 	if err != nil {
 		if errors.Is(err, config.ErrTemplateNotFound) {
@@ -128,8 +139,8 @@ func (u *configServiceImpl) GetTemplate(ctx context.Context, tem config.Namespac
 }
 
 func (u *configServiceImpl) CreateConfig(ctx context.Context, project string, req apis.CreateConfigRequest) (*apis.Config, error) {
-	ns := types.DefaultKubeVelaNS
-	if project != "" {
+	ns := GlobalConfigNamespace
+	if !isGlobal(project) {
 		pro, err := u.ProjectService.GetProject(ctx, project)
 		if err != nil {
 			return nil, err
@@ -138,7 +149,7 @@ func (u *configServiceImpl) CreateConfig(ctx context.Context, project string, re
 	}
 	exist, err := u.Factory.IsExist(ctx, ns, req.Name)
 	if err != nil {
-		klog.Errorf("check config name is exist failure %s", err.Error())
+		klog.Errorf("check config name exist fail %s", err.Error())
 		return nil, bcode.ErrConfigExist
 	}
 	if exist {
@@ -149,7 +160,7 @@ func (u *configServiceImpl) CreateConfig(ctx context.Context, project string, re
 		return nil, err
 	}
 	if req.Template.Namespace == "" {
-		req.Template.Namespace = types.DefaultKubeVelaNS
+		req.Template.Namespace = GlobalConfigNamespace
 	}
 	configItem, err := u.Factory.ParseConfig(ctx, config.NamespacedName(req.Template), config.Metadata{
 		NamespacedName: config.NamespacedName{Name: req.Name, Namespace: ns},
@@ -169,8 +180,8 @@ func (u *configServiceImpl) CreateConfig(ctx context.Context, project string, re
 }
 
 func (u *configServiceImpl) UpdateConfig(ctx context.Context, project string, name string, req apis.UpdateConfigRequest) (*apis.Config, error) {
-	ns := types.DefaultKubeVelaNS
-	if project != "" {
+	ns := GlobalConfigNamespace
+	if !isGlobal(project) {
 		pro, err := u.ProjectService.GetProject(ctx, project)
 		if err != nil {
 			return nil, err
@@ -217,8 +228,8 @@ func (u *configServiceImpl) ListConfigs(ctx context.Context, project string, tem
 	var list []*apis.Config
 	scope := ""
 	var projectNamespace string
-	listCtx := utils.WithProject(ctx, "")
-	if project != "" {
+	listCtx := utils.WithProject(ctx, NoProject)
+	if !isGlobal(project) {
 		scope = "project"
 		pro, err := u.ProjectService.GetProject(ctx, project)
 		if err != nil {
@@ -235,7 +246,7 @@ func (u *configServiceImpl) ListConfigs(ctx context.Context, project string, tem
 		}
 	}
 
-	configs, err := u.Factory.ListConfigs(listCtx, types.DefaultKubeVelaNS, template, scope, true)
+	configs, err := u.Factory.ListConfigs(listCtx, GlobalConfigNamespace, template, scope, true)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +294,7 @@ func (u *configServiceImpl) CreateConfigDistribution(ctx context.Context, projec
 	})
 }
 
-// ListDistributeConfigs list the all distributions
+// ListConfigDistributions list the all distributions
 func (u *configServiceImpl) ListConfigDistributions(ctx context.Context, project string) ([]*config.Distribution, error) {
 	pro, err := u.ProjectService.GetProject(ctx, project)
 	if err != nil {
@@ -324,8 +335,8 @@ func convertConfig(project string, config config.Config) *apis.Config {
 }
 
 func (u *configServiceImpl) GetConfig(ctx context.Context, project, name string) (*apis.Config, error) {
-	ns := types.DefaultKubeVelaNS
-	if project != "" {
+	ns := GlobalConfigNamespace
+	if !isGlobal(project) {
 		pro, err := u.ProjectService.GetProject(ctx, project)
 		if err != nil {
 			return nil, err
@@ -339,7 +350,8 @@ func (u *configServiceImpl) GetConfig(ctx context.Context, project, name string)
 			return nil, bcode.ErrSensitiveConfig
 		}
 		if errors.Is(err, config.ErrConfigNotFound) {
-			return nil, bcode.ErrConfigNotFound
+			// Try to get global config
+			return u.GetConfig(ctx, NoProject, name)
 		}
 		return nil, err
 	}
@@ -348,8 +360,8 @@ func (u *configServiceImpl) GetConfig(ctx context.Context, project, name string)
 }
 
 func (u *configServiceImpl) DeleteConfig(ctx context.Context, project, name string) error {
-	ns := types.DefaultKubeVelaNS
-	if project != "" {
+	ns := GlobalConfigNamespace
+	if !isGlobal(project) {
 		pro, err := u.ProjectService.GetProject(ctx, project)
 		if err != nil {
 			return err

--- a/pkg/server/domain/service/config.go
+++ b/pkg/server/domain/service/config.go
@@ -349,8 +349,8 @@ func (u *configServiceImpl) GetConfig(ctx context.Context, project, name string)
 		if errors.Is(err, config.ErrSensitiveConfig) {
 			return nil, bcode.ErrSensitiveConfig
 		}
-		if errors.Is(err, config.ErrConfigNotFound) {
-			// Try to get global config
+		if errors.Is(err, config.ErrConfigNotFound) && !isGlobal(project) {
+			// Try to get global config if the config is not found in the project scope.
 			return u.GetConfig(ctx, NoProject, name)
 		}
 		return nil, err

--- a/pkg/server/domain/service/config_test.go
+++ b/pkg/server/domain/service/config_test.go
@@ -101,6 +101,69 @@ template: {
 	}
 }
 `
+var (
+	helmTemplateName = "helm-repository"
+	helmTemplate     = `
+import (
+	"vela/config"
+)
+
+metadata: {
+	name:        "helm-repository"
+	alias:       "Helm Repository"
+	description: "Config information to authenticate helm chart repository"
+	sensitive:   false
+	scope:       "project"
+}
+
+template: {
+	output: {
+		apiVersion: "v1"
+		kind:       "Secret"
+		metadata: {
+			name:      context.name
+			namespace: context.namespace
+			labels: {
+				"config.oam.dev/catalog":       "velacore-config"
+				"config.oam.dev/type":          "helm-repository"
+				"config.oam.dev/multi-cluster": "true"
+				"config.oam.dev/sub-type":      "helm"
+			}
+		}
+		type: "Opaque"
+		stringData: {
+			url: parameter.url
+			if parameter.username != _|_ {
+				username: parameter.username
+			}
+			if parameter.password != _|_ {
+				password: parameter.password
+			}
+
+		}
+		data: {
+			if parameter.caFile != _|_ {
+				caFile: parameter.caFile
+			}
+		}
+	}
+    // skip the validation here for config.#HelmRepository requires the repository actually exists which can be flaky in unit test 
+	//validation: config.#HelmRepository & {
+	//			 $params: parameter
+	//}
+
+	parameter: {
+		// +usage=The public url of the helm chart repository.
+		url: string
+		// +usage=The username of basic auth repo.
+		username?: string
+		// +usage=The password of basic auth repo.
+		password?: string
+		// +usage=The ca certificate of helm repository. Please encode this data with base64.
+		caFile?: string
+	}
+}`
+)
 
 var _ = Describe("Test config service", func() {
 	var factory config.Factory
@@ -180,9 +243,36 @@ var _ = Describe("Test config service", func() {
 		Expect(len(list)).To(Equal(0))
 	})
 
-	It("Test detail a config", func() {
-		_, err := configService.GetConfig(context.TODO(), "", "alibaba-test")
-		Expect(err).To(Equal(bcode.ErrSensitiveConfig))
+	Context("Test get config", func() {
+		It("Simple get", func() {
+			_, err := configService.GetConfig(context.TODO(), "", "alibaba-test")
+			Expect(err).To(Equal(bcode.ErrSensitiveConfig))
+		})
+
+		It("Get config in project and fall back to get global config", func() {
+			By("apply helm template")
+			tem, err := factory.ParseTemplate(helmTemplateName, []byte(helmTemplate))
+			Expect(err).To(BeNil())
+			Expect(factory.CreateOrUpdateConfigTemplate(context.Background(), types.DefaultKubeVelaNS, tem)).To(BeNil())
+
+			By("create a project")
+			_, err = projectService.CreateProject(context.TODO(), v1.CreateProjectRequest{Name: "some-project"})
+			Expect(err).To(BeNil())
+			By("create a common global config")
+			_, err = configService.CreateConfig(context.TODO(), NoProject, v1.CreateConfigRequest{
+				Name: "helm-test",
+				Template: v1.NamespacedName{
+					Name: helmTemplateName,
+				},
+				Properties: `{"username":"test","password":"test","url":"https://helm.kubevela.com/charts"}`,
+			})
+			Expect(err).To(BeNil())
+			By("try to get the config in project, should success")
+			config, err := configService.GetConfig(context.TODO(), "some-project", "helm-test")
+			Expect(err).To(BeNil())
+			Expect(config.Name).To(Equal("helm-test"))
+		})
+
 	})
 
 	It("Test delete a config", func() {

--- a/pkg/server/domain/service/config_test.go
+++ b/pkg/server/domain/service/config_test.go
@@ -258,6 +258,9 @@ var _ = Describe("Test config service", func() {
 			By("create a project")
 			_, err = projectService.CreateProject(context.TODO(), v1.CreateProjectRequest{Name: "some-project"})
 			Expect(err).To(BeNil())
+			defer func() {
+				Expect(projectService.DeleteProject(context.Background(), "some-project")).To(BeNil())
+			}()
 			By("create a common global config")
 			_, err = configService.CreateConfig(context.TODO(), NoProject, v1.CreateConfigRequest{
 				Name: "helm-test",
@@ -267,6 +270,9 @@ var _ = Describe("Test config service", func() {
 				Properties: `{"username":"test","password":"test","url":"https://helm.kubevela.com/charts"}`,
 			})
 			Expect(err).To(BeNil())
+			defer func() {
+				Expect(configService.DeleteConfig(context.Background(), NoProject, "helm-test")).To(BeNil())
+			}()
 			By("try to get the config in project, should success")
 			config, err := configService.GetConfig(context.TODO(), "some-project", "helm-test")
 			Expect(err).To(BeNil())

--- a/pkg/server/domain/service/helm.go
+++ b/pkg/server/domain/service/helm.go
@@ -175,10 +175,10 @@ func (d defaultHelmImpl) ListChartRepo(ctx context.Context, projectName string) 
 			url, ok := item.Properties["url"].(string)
 			if ok {
 				res = append(res, &v1.ChartRepoResponse{URL: url, SecretName: item.Name})
+				continue
 			}
-		}
-		// Compatible with historical data
-		if url, ok := item.Secret.Data["url"]; ok {
+		} else if url, ok := item.Secret.Data["url"]; ok {
+			// Compatible with historical data
 			res = append(res, &v1.ChartRepoResponse{URL: string(url), SecretName: item.Name})
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>

### Description of your changes

The logic in `GetConfig` interface will return `extract auth info from secret error` when the configured helm repo is from global config. 

<img width="1224" alt="image" src="https://github.com/kubevela/velaux/assets/47812250/27656aab-fab4-4967-9733-d4bfcdd21b79">

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [x] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
