### PR TITLE
Feat: support exit-on-lost-leader flag

### DIFF
--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -58,6 +58,9 @@ type Config struct {
 	PluginConfig PluginConfig
 
 	DexServerURL string
+
+	// ExitOnLostLeader will exit the process if this server lost the leader election, set this to true for debugging
+	ExitOnLostLeader bool
 }
 
 // PluginConfig the plugin directory config
@@ -95,7 +98,8 @@ func NewConfig() *Config {
 			CorePluginPath:   "core-plugins",
 			CustomPluginPath: []string{"plugins"},
 		},
-		DexServerURL: "http://dex.vela-system:5556",
+		DexServerURL:     "http://dex.vela-system:5556",
+		ExitOnLostLeader: true,
 	}
 }
 
@@ -127,5 +131,6 @@ func (s *Config) AddFlags(fs *pflag.FlagSet, c *Config) {
 	fs.StringVar(&s.WorkflowVersion, "workflow-version", c.WorkflowVersion, "the version of workflow to meet controller requirement.")
 	fs.StringVar(&s.DexServerURL, "dex-server", c.DexServerURL, "the URL of the dex server.")
 	fs.StringArrayVar(&s.PluginConfig.CustomPluginPath, "plugin-path", c.PluginConfig.CustomPluginPath, "the path of the plugin directory")
+	fs.BoolVar(&s.ExitOnLostLeader, "exit-on-lost-leader", c.ExitOnLostLeader, "exit the process if this server lost the leader election")
 	profiling.AddFlags(fs)
 }

--- a/pkg/server/domain/service/workflow.go
+++ b/pkg/server/domain/service/workflow.go
@@ -445,7 +445,7 @@ func (w *workflowServiceImpl) SyncWorkflowRecord(ctx context.Context, appPrimary
 				record.Finished = "true"
 				record.Status = model.RevisionStatusFail
 				if err := w.Store.Put(ctx, record); err != nil {
-					return fmt.Errorf(("failed to set the record status to terminated: %s"), err.Error())
+					return fmt.Errorf("failed to set the record status to terminated: %s", err.Error())
 				}
 				return bcode.ErrApplicationRevisionNotExist
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -253,7 +253,9 @@ func (s *restServer) setupLeaderElection(errChan chan error) (*leaderelection.Le
 				go event.StartEventWorker(ctx, errChan)
 			},
 			OnStoppedLeading: func() {
-				errChan <- fmt.Errorf("leader lost %s", s.cfg.LeaderConfig.ID)
+				if s.cfg.ExitOnLostLeader {
+					errChan <- fmt.Errorf("leader lost %s", s.cfg.LeaderConfig.ID)
+				}
 			},
 			OnNewLeader: func(identity string) {
 				if identity == s.cfg.LeaderConfig.ID {


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Currently if we step-by-step debug the server for a longer time than `RenewDeadline` of leader election, the program will exit. This PR support a flag to switch this behavior.

If server starts with `--exit-on-lost-leader=false`, the server will keep running and try to become leader. If the debugging program is the only replica, it will become leader soon.

This PR also add a retry mechanism for application workflow sync. The max failure times is 5.

Fixes #

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
