### PR TITLE
Fix: fix swagger.json

### DIFF
--- a/docs/apidoc/swagger-3.0.json
+++ b/docs/apidoc/swagger-3.0.json
@@ -1,0 +1,19877 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Kubevela api doc",
+    "description": "Kubevela api doc",
+    "contact": {
+      "name": "kubevela",
+      "url": "https://kubevela.io/",
+      "email": "feedback@mail.kubevela.io"
+    },
+    "license": {
+      "name": "Apache License 2.0",
+      "url": "https://github.com/oam-dev/kubevela/blob/master/LICENSE"
+    },
+    "version": "v1beta1"
+  },
+  "servers": [
+    {
+      "url": "http://localhost/"
+    },
+    {
+      "url": "http://localhost:8000/"
+    }
+  ],
+  "security": [
+    { 
+      "BearerAuth": []
+    }
+  ],
+  "paths": {
+    "/api/v1/addon_registries": {
+      "get": {
+        "tags": [
+          "addon_registry"
+        ],
+        "summary": "list all addon registry",
+        "operationId": "listAddonRegistry",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListAddonRegistryResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListAddonRegistryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "addon_registry"
+        ],
+        "summary": "create an addon registry",
+        "operationId": "createAddonRegistry",
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateAddonRegistryRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateAddonRegistryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonRegistry"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonRegistry"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/addon_registries/{addonRegName}": {
+      "put": {
+        "tags": [
+          "addon_registry"
+        ],
+        "summary": "update an addon registry",
+        "operationId": "updateAddonRegistry",
+        "parameters": [
+          {
+            "name": "addonRegName",
+            "in": "path",
+            "description": "identifier of the addon registry",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateAddonRegistryRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateAddonRegistryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonRegistry"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonRegistry"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "addon_registry"
+        ],
+        "summary": "delete an addon registry",
+        "operationId": "deleteAddonRegistry",
+        "parameters": [
+          {
+            "name": "addonRegName",
+            "in": "path",
+            "description": "identifier of the addon registry",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonRegistry"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonRegistry"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/addons": {
+      "get": {
+        "tags": [
+          "addon"
+        ],
+        "summary": "list all addons",
+        "operationId": "listAddons",
+        "parameters": [
+          {
+            "name": "registry",
+            "in": "query",
+            "description": "filter addons from given registry",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Fuzzy search based on name and description.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListAddonResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListAddonResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/addons/{addonName}": {
+      "get": {
+        "tags": [
+          "addon"
+        ],
+        "summary": "show details of an addon",
+        "operationId": "detailAddon",
+        "parameters": [
+          {
+            "name": "version",
+            "in": "query",
+            "description": "specify addon version to enable",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "addonName",
+            "in": "path",
+            "description": "addon name to query detail",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "registry",
+            "in": "query",
+            "description": "filter addons from given registry",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailAddonResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailAddonResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/addons/{addonName}/disable": {
+      "post": {
+        "tags": [
+          "addon"
+        ],
+        "summary": "disable an addon",
+        "operationId": "disableAddon",
+        "parameters": [
+          {
+            "name": "addonName",
+            "in": "path",
+            "description": "addon name to enable",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "force disable an addon",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonStatusResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/addons/{addonName}/enable": {
+      "post": {
+        "tags": [
+          "addon"
+        ],
+        "summary": "enable an addon",
+        "operationId": "enableAddon",
+        "parameters": [
+          {
+            "name": "addonName",
+            "in": "path",
+            "description": "addon name to enable",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.EnableAddonRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.EnableAddonRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonStatusResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/addons/{addonName}/status": {
+      "get": {
+        "tags": [
+          "addon"
+        ],
+        "summary": "show status of an addon",
+        "operationId": "statusAddon",
+        "parameters": [
+          {
+            "name": "addonName",
+            "in": "path",
+            "description": "addon name to query status",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonStatusResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/addons/{addonName}/update": {
+      "put": {
+        "tags": [
+          "addon"
+        ],
+        "summary": "update an addon",
+        "operationId": "updateAddon",
+        "parameters": [
+          {
+            "name": "addonName",
+            "in": "path",
+            "description": "addon name to update",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.EnableAddonRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.EnableAddonRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonStatusResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AddonStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/applications": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "list all applications",
+        "operationId": "listApplications",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Fuzzy search based on name or description",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "project",
+            "in": "query",
+            "description": "search base on project name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "env",
+            "in": "query",
+            "description": "search base on env name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "targetName",
+            "in": "query",
+            "description": "Name of the application delivery target",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListApplicationResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListApplicationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "create one application ",
+        "operationId": "createApplication",
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateApplicationRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateApplicationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/applications/{appName}": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "detail one application ",
+        "operationId": "detailApplication",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailApplicationResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailApplicationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "application"
+        ],
+        "summary": "update one application ",
+        "operationId": "updateApplication",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateApplicationRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateApplicationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "application"
+        ],
+        "summary": "delete one application",
+        "operationId": "deleteApplication",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/compare": {
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "compare application",
+        "operationId": "compareApp",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.AppCompareReq"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.AppCompareReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AppCompareResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AppCompareResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/applications/{appName}/components": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "gets the list of application components",
+        "operationId": "listApplicationComponents",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "envName",
+            "in": "query",
+            "description": "list components that deployed in define env",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ComponentListResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ComponentListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "create component  for application ",
+        "operationId": "createComponent",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateComponentRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateComponentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ComponentBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ComponentBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/applications/{appName}/components/{compName}": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "detail component for application ",
+        "operationId": "detailComponent",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "compName",
+            "in": "path",
+            "description": "identifier of the component",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailComponentResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailComponentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "application"
+        ],
+        "summary": "update component config",
+        "operationId": "updateComponent",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "compName",
+            "in": "path",
+            "description": "identifier of the component",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateApplicationComponentRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateApplicationComponentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ComponentBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ComponentBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "application"
+        ],
+        "summary": "delete a component",
+        "operationId": "deleteComponent",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "compName",
+            "in": "path",
+            "description": "identifier of the component",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/components/{compName}/traits": {
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "add trait for a component",
+        "operationId": "addApplicationTrait",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "compName",
+            "in": "path",
+            "description": "identifier of the component",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateApplicationTraitRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateApplicationTraitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/applications/{appName}/components/{compName}/traits/{traitType}": {
+      "put": {
+        "tags": [
+          "application"
+        ],
+        "summary": "update trait from a component",
+        "operationId": "updateApplicationTrait",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "compName",
+            "in": "path",
+            "description": "identifier of the component",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "traitType",
+            "in": "path",
+            "description": "identifier of the type of trait",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateApplicationTraitRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateApplicationTraitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationTrait"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationTrait"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "application"
+        ],
+        "summary": "delete trait from a component",
+        "operationId": "deleteApplicationTrait",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "compName",
+            "in": "path",
+            "description": "identifier of the component",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "traitType",
+            "in": "path",
+            "description": "identifier of the type of trait",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationTrait"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationTrait"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/deploy": {
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "deploy or upgrade the application",
+        "operationId": "deployApplication",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.ApplicationDeployRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.ApplicationDeployRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationDeployResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationDeployResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/applications/{appName}/dry-run": {
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "dry-run application to latest revision",
+        "operationId": "dryRunAppOrRevision",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.AppDryRunReq"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.AppDryRunReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AppDryRunResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AppDryRunResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/applications/{appName}/envs": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "list policy for application",
+        "operationId": "listApplicationEnvs",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListApplicationEnvBinding"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListApplicationEnvBinding"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "creating an application environment ",
+        "operationId": "createApplicationEnv",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateApplicationEnvbindingRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateApplicationEnvbindingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EnvBinding"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EnvBinding"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/applications/{appName}/envs/{envName}": {
+      "put": {
+        "tags": [
+          "application"
+        ],
+        "summary": "set application  differences in the specified environment",
+        "operationId": "updateApplicationEnv",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "envName",
+            "in": "path",
+            "description": "identifier of the envBinding ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.PutApplicationEnvBindingRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.PutApplicationEnvBindingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EnvBinding"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EnvBinding"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "application"
+        ],
+        "summary": "delete an application environment ",
+        "operationId": "deleteApplicationEnv",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "envName",
+            "in": "path",
+            "description": "identifier of the envBinding ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/envs/{envName}/records": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "query application workflow execution record of one environment",
+        "operationId": "listWorkflowRecordsFromEnv",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "envName",
+            "in": "path",
+            "description": "identifier of the environment.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "query the page number",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "query the page size number",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListWorkflowRecordsResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListWorkflowRecordsResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/envs/{envName}/recycle": {
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "recycle application env",
+        "operationId": "recycleApplicationEnv",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "envName",
+            "in": "path",
+            "description": "identifier of the application envbinding",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/envs/{envName}/status": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "get application status",
+        "operationId": "getApplicationStatus",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "envName",
+            "in": "path",
+            "description": "identifier of the application envbinding",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationStatusResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/policies": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "list policy for application",
+        "operationId": "listApplicationPolicies",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListApplicationPolicy"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListApplicationPolicy"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "create policy for application",
+        "operationId": "createApplicationPolicy",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreatePolicyRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreatePolicyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PolicyBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PolicyBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/applications/{appName}/policies/{policyName}": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "detail policy for application",
+        "operationId": "detailApplicationPolicy",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "identifier of the application policy",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailPolicyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailPolicyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "application"
+        ],
+        "summary": "update policy for application",
+        "operationId": "updateApplicationPolicy",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "identifier of the application policy",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdatePolicyRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdatePolicyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailPolicyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailPolicyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "application"
+        ],
+        "summary": "detail policy for application",
+        "operationId": "deleteApplicationPolicy",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "identifier of the application policy",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Force delete the policy and all references",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/records": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "list application records",
+        "operationId": "listApplicationRecords",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {}
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/reset": {
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "reset application to latest revision",
+        "operationId": "resetAppToLatestRevision",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AppResetResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AppResetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/revisions": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "list revisions for application",
+        "operationId": "listApplicationRevisions",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "envName",
+            "in": "query",
+            "description": "query identifier of the env",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "query identifier of the status",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "query the page number",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "query the page size number",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListRevisionsResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListRevisionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/revisions/{revision}": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "detail revision for application",
+        "operationId": "detailApplicationRevision",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "revision",
+            "in": "path",
+            "description": "identifier of the application revision",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailRevisionResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailRevisionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/revisions/{revision}/rollback": {
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "detail revision for application",
+        "operationId": "rollbackApplicationWithRevision",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "revision",
+            "in": "path",
+            "description": "identifier of the application revision",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationRollbackResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationRollbackResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/statistics": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "detail one application ",
+        "operationId": "applicationStatistics",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationStatisticsResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationStatisticsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/status": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "get application status from all envs",
+        "operationId": "getApplicationStatusFromAllEnvs",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationStatusListResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationStatusListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/template": {
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "create one application template",
+        "operationId": "publishApplicationTemplate",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateApplicationTemplateRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateApplicationTemplateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationTemplateBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationTemplateBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/applications/{appName}/triggers": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "List the application triggers",
+        "operationId": "listApplicationTriggers",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListApplicationTriggerResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListApplicationTriggerResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "Create an application trigger",
+        "operationId": "createApplicationTrigger",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateApplicationTriggerRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateApplicationTriggerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationTriggerBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationTriggerBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/applications/{appName}/triggers/{token}": {
+      "put": {
+        "tags": [
+          "application"
+        ],
+        "summary": "Update an application trigger",
+        "operationId": "updateApplicationTrigger",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "token",
+            "in": "path",
+            "description": "identifier of the trigger",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationTriggerBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationTriggerBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "application"
+        ],
+        "summary": "Delete an application trigger",
+        "operationId": "deleteApplicationTrigger",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "token",
+            "in": "path",
+            "description": "identifier of the trigger",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/workflows": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "list application workflow",
+        "operationId": "listApplicationWorkflows",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListWorkflowResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListWorkflowResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "application"
+        ],
+        "summary": "create application workflow",
+        "operationId": "createOrUpdateApplicationWorkflow",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateWorkflowRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateWorkflowRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "create success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailWorkflowResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailWorkflowResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "create failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/applications/{appName}/workflows/{workflowName}": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "detail application workflow",
+        "operationId": "detailWorkflow",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workflowName",
+            "in": "path",
+            "description": "identifier of the workflow.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "create success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailWorkflowResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailWorkflowResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "application"
+        ],
+        "summary": "update application workflow config",
+        "operationId": "updateWorkflow",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workflowName",
+            "in": "path",
+            "description": "identifier of the workflow",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateWorkflowRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateWorkflowRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailWorkflowResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailWorkflowResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "application"
+        ],
+        "summary": "delete workflow",
+        "operationId": "deleteWorkflow",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workflowName",
+            "in": "path",
+            "description": "identifier of the workflow",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SimpleResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SimpleResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/workflows/{workflowName}/records": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "query application workflow execution record",
+        "operationId": "listWorkflowRecords",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workflowName",
+            "in": "path",
+            "description": "identifier of the workflow",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "query the page number",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "query the page size number",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListWorkflowRecordsResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListWorkflowRecordsResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/workflows/{workflowName}/records/{record}": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "query application workflow execution record detail",
+        "operationId": "detailWorkflowRecord",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workflowName",
+            "in": "path",
+            "description": "identifier of the workflow",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "record",
+            "in": "path",
+            "description": "identifier of the workflow record",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailWorkflowRecordResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailWorkflowRecordResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/workflows/{workflowName}/records/{record}/inputs": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "get the workflow step inputs",
+        "operationId": "getWorkflowRecordInputs",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workflowName",
+            "in": "path",
+            "description": "identifier of the workflow",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "record",
+            "in": "path",
+            "description": "identifier of the workflow record",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "step",
+            "in": "query",
+            "description": "Specified the step filter",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetPipelineRunInputResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetPipelineRunInputResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/workflows/{workflowName}/records/{record}/logs": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "get the workflow step logs",
+        "operationId": "getWorkflowRecordLogs",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workflowName",
+            "in": "path",
+            "description": "identifier of the workflow",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "record",
+            "in": "path",
+            "description": "identifier of the workflow record",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "step",
+            "in": "query",
+            "description": "Specified the step filter",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {}
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/workflows/{workflowName}/records/{record}/outputs": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "get the workflow step inputs",
+        "operationId": "getWorkflowRecordOutputs",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workflowName",
+            "in": "path",
+            "description": "identifier of the workflow",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "record",
+            "in": "path",
+            "description": "identifier of the workflow record",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "step",
+            "in": "query",
+            "description": "Specified the step filter",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetPipelineRunOutputResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetPipelineRunOutputResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/workflows/{workflowName}/records/{record}/resume": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "resume suspend workflow record",
+        "operationId": "resumeWorkflowRecord",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workflowName",
+            "in": "path",
+            "description": "identifier of the workflow",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "record",
+            "in": "path",
+            "description": "identifier of the  workflow record",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "step",
+            "in": "query",
+            "description": "resume the workflow with specific step",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/workflows/{workflowName}/records/{record}/rollback": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "rollback suspend application record",
+        "operationId": "rollbackWorkflowRecord",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workflowName",
+            "in": "path",
+            "description": "identifier of the workflow",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "record",
+            "in": "path",
+            "description": "identifier of the workflow record",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rollbackVersion",
+            "in": "query",
+            "description": "identifier of the rollback revision",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.WorkflowRecordBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.WorkflowRecordBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/applications/{appName}/workflows/{workflowName}/records/{record}/terminate": {
+      "get": {
+        "tags": [
+          "application"
+        ],
+        "summary": "terminate suspend workflow record",
+        "operationId": "terminateWorkflowRecord",
+        "parameters": [
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "identifier of the application.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "workflowName",
+            "in": "path",
+            "description": "identifier of the workflow",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "record",
+            "in": "path",
+            "description": "identifier of the workflow record",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/admin_configured": {
+      "get": {
+        "tags": [
+          "authentication"
+        ],
+        "summary": "check admin is configured",
+        "operationId": "adminConfigured",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AdminConfiguredResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.AdminConfiguredResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/dex_config": {
+      "get": {
+        "tags": [
+          "authentication"
+        ],
+        "summary": "get Dex config",
+        "operationId": "getDexConfig",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DexConfigResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DexConfigResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/init_admin": {
+      "put": {
+        "tags": [
+          "authentication"
+        ],
+        "summary": "initialize admin",
+        "operationId": "configureAdmin",
+        "security": [],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.InitAdminRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.InitAdminRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InitAdminResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.InitAdminResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "tags": [
+          "authentication"
+        ],
+        "summary": "handle login request",
+        "operationId": "login",
+        "security": [],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.LoginRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.LoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.LoginResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.LoginResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/auth/login_type": {
+      "get": {
+        "tags": [
+          "authentication"
+        ],
+        "summary": "get login type",
+        "operationId": "getLoginType",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetLoginTypeResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetLoginTypeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/refresh_token": {
+      "get": {
+        "tags": [
+          "authentication"
+        ],
+        "summary": "refresh token",
+        "operationId": "refreshToken",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.RefreshTokenResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.RefreshTokenResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/user_info": {
+      "get": {
+        "tags": [
+          "authentication"
+        ],
+        "summary": "get login user detail info",
+        "operationId": "getLoginUserInfo",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.LoginUserInfoResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.LoginUserInfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/cloudshell": {
+      "post": {
+        "tags": [
+          "cloudshell"
+        ],
+        "summary": "prepare the user's cloud shell environment",
+        "operationId": "prepareCloudShell",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.CloudShellPrepareResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.CloudShellPrepareResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "cloudshell"
+        ],
+        "summary": "destroy the user's cloud shell environment",
+        "operationId": "destroyCloudShell",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SimpleResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SimpleResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/clusters": {
+      "get": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "list all clusters",
+        "operationId": "listKubeClusters",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Fuzzy search based on name or description",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page for paging",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "PageSize for paging",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListClusterResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListClusterResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "create cluster",
+        "operationId": "createKubeCluster",
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateClusterRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateClusterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ClusterBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ClusterBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/clusters/cloud_clusters/{provider}": {
+      "post": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "list cloud clusters",
+        "operationId": "listCloudClusters",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "description": "identifier of the cloud provider",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page for paging",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "PageSize for paging",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.AccessKeyRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.AccessKeyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListCloudClusterResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListCloudClusterResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/clusters/cloud_clusters/{provider}/connect": {
+      "post": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "create cluster from cloud cluster",
+        "operationId": "connectCloudCluster",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "description": "identifier of the cloud provider",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.ConnectCloudClusterRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.ConnectCloudClusterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ClusterBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ClusterBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/clusters/cloud_clusters/{provider}/create": {
+      "post": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "create cloud cluster",
+        "operationId": "createCloudCluster",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "description": "identifier of the cloud provider",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateCloudClusterRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateCloudClusterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.CreateCloudClusterResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.CreateCloudClusterResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/clusters/cloud_clusters/{provider}/creation": {
+      "get": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "list cloud cluster creation",
+        "operationId": "listCloudClusterCreation",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "description": "identifier of the cloud provider",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListCloudClusterCreationResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListCloudClusterCreationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/clusters/cloud_clusters/{provider}/creation/{cloudClusterName}": {
+      "get": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "check cloud cluster create status",
+        "operationId": "getCloudClusterCreationStatus",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "description": "identifier of the cloud provider",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cloudClusterName",
+            "in": "path",
+            "description": "identifier for cloud cluster which is creating",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.CreateCloudClusterResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.CreateCloudClusterResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "delete cloud cluster creation",
+        "operationId": "deleteCloudClusterCreation",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "description": "identifier of the cloud provider",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cloudClusterName",
+            "in": "path",
+            "description": "identifier for cloud cluster which is creating",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.CreateCloudClusterResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.CreateCloudClusterResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/clusters/{clusterName}": {
+      "get": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "detail cluster info",
+        "operationId": "getKubeCluster",
+        "parameters": [
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "identifier of the cluster",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailClusterResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailClusterResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "modify cluster",
+        "operationId": "modifyKubeCluster",
+        "parameters": [
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "identifier of the cluster",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateClusterRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateClusterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ClusterBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ClusterBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "delete cluster",
+        "operationId": "deleteKubeCluster",
+        "parameters": [
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "identifier of the cluster",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ClusterBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ClusterBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/clusters/{clusterName}/namespaces": {
+      "post": {
+        "tags": [
+          "cluster"
+        ],
+        "summary": "create namespace in cluster",
+        "operationId": "createNamespace",
+        "parameters": [
+          {
+            "name": "clusterName",
+            "in": "path",
+            "description": "name of the target cluster",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateClusterNamespaceRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateClusterNamespaceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.CreateClusterNamespaceResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.CreateClusterNamespaceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/config_templates": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "List all config templates from the system namespace",
+        "operationId": "listConfigTemplates",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListConfigTemplateResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListConfigTemplateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config_templates/{templateName}": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Detail a template",
+        "operationId": "getConfigTemplate",
+        "parameters": [
+          {
+            "name": "templateName",
+            "in": "path",
+            "description": "identifier of the config template",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "namespace",
+            "in": "query",
+            "description": "the name of the namespace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ConfigTemplateDetail"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ConfigTemplateDetail"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/configs": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "list all configs that belong to the system scope",
+        "operationId": "getConfigs",
+        "parameters": [
+          {
+            "name": "template",
+            "in": "query",
+            "description": "the name of the template",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListConfigResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListConfigResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "create or update a config",
+        "operationId": "createConfig",
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateConfigRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateConfigRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Config"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Config"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/configs/{configName}": {
+      "get": {
+        "tags": [
+          "config"
+        ],
+        "summary": "detail a config",
+        "operationId": "getConfig",
+        "parameters": [
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "identifier of the config",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/*v1.Config"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/*v1.Config"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "config"
+        ],
+        "summary": "update a config",
+        "operationId": "updateConfig",
+        "parameters": [
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "identifier of the config",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/*v1.UpdateConfigRequest"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/*v1.UpdateConfigRequest"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "config"
+        ],
+        "summary": "delete a config",
+        "operationId": "deleteConfig",
+        "parameters": [
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "identifier of the config",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/definitions": {
+      "get": {
+        "tags": [
+          "definition"
+        ],
+        "summary": "list all definitions",
+        "operationId": "listDefinitions",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "description": "query the definition type",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "component",
+                "trait",
+                "workflowstep",
+                "policy"
+              ]
+            }
+          },
+          {
+            "name": "queryAll",
+            "in": "query",
+            "description": "query all definitions include hidden in UI",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "appliedWorkload",
+            "in": "query",
+            "description": "if specified, query the trait definition applied to the workload",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ownerAddon",
+            "in": "query",
+            "description": "query by which addon created the definition",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "description": "query by the specified scope like WorkflowRun or Application",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListDefinitionResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListDefinitionResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/definitions/{definitionName}": {
+      "get": {
+        "tags": [
+          "definition"
+        ],
+        "summary": "Detail a definition",
+        "operationId": "detailDefinition",
+        "parameters": [
+          {
+            "name": "definitionName",
+            "in": "path",
+            "description": "identifier of the definition",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "query the definition type",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "create successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailDefinitionResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailDefinitionResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/definitions/{definitionName}/status": {
+      "put": {
+        "tags": [
+          "definition"
+        ],
+        "summary": "Update the status for a definition",
+        "operationId": "updateDefinitionStatus",
+        "parameters": [
+          {
+            "name": "definitionName",
+            "in": "path",
+            "description": "identifier of the definition",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateDefinitionStatusRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateDefinitionStatusRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "update successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/*schema.UIParameter"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/*schema.UIParameter"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/definitions/{definitionName}/uischema": {
+      "put": {
+        "tags": [
+          "definition"
+        ],
+        "summary": "Update the UI schema for a definition",
+        "operationId": "updateUISchema",
+        "parameters": [
+          {
+            "name": "definitionName",
+            "in": "path",
+            "description": "identifier of the definition",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateUISchemaRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateUISchemaRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "update successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/*schema.UIParameter"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/*schema.UIParameter"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/enabled_addon": {
+      "get": {
+        "tags": [
+          "addon"
+        ],
+        "summary": "list all enabled addons",
+        "operationId": "list",
+        "parameters": [
+          {
+            "name": "registry",
+            "in": "query",
+            "description": "filter addons from given registry",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Fuzzy search based on name and description.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListEnabledAddonResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListEnabledAddonResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/envs": {
+      "get": {
+        "tags": [
+          "env"
+        ],
+        "summary": "list all envs",
+        "operationId": "envlist",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListEnvResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListEnvResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "env"
+        ],
+        "summary": "create an env",
+        "operationId": "envcreate",
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateEnvRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateEnvRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Env"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Env"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/envs/{envName}": {
+      "put": {
+        "tags": [
+          "env"
+        ],
+        "summary": "update an env",
+        "operationId": "envupdate",
+        "parameters": [
+          {
+            "name": "envName",
+            "in": "path",
+            "description": "identifier of the environment",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateEnvRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateEnvRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Env"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Env"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "env"
+        ],
+        "summary": "delete one env",
+        "operationId": "envdelete",
+        "parameters": [
+          {
+            "name": "envName",
+            "in": "path",
+            "description": "identifier of the environment",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/manage/plugins": {
+      "get": {
+        "tags": [
+          "Plugin"
+        ],
+        "summary": "List the installed plugins",
+        "operationId": "listInstalledPlugins",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListPluginResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListPluginResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/manage/plugins/{pluginId}": {
+      "get": {
+        "tags": [
+          "Plugin"
+        ],
+        "summary": "Detail an installed plugin",
+        "operationId": "detailPlugin",
+        "parameters": [
+          {
+            "name": "pluginId",
+            "in": "path",
+            "description": "identifier of the plugin.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ManagedPluginDTO"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ManagedPluginDTO"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/manage/plugins/{pluginId}/disable": {
+      "post": {
+        "tags": [
+          "Plugin"
+        ],
+        "summary": "Disable an installed plugin",
+        "operationId": "disablePlugin",
+        "parameters": [
+          {
+            "name": "pluginId",
+            "in": "path",
+            "description": "identifier of the plugin.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ManagedPluginDTO"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ManagedPluginDTO"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/manage/plugins/{pluginId}/enable": {
+      "post": {
+        "tags": [
+          "Plugin"
+        ],
+        "summary": "Enable an installed plugin",
+        "operationId": "enablePlugin",
+        "parameters": [
+          {
+            "name": "pluginId",
+            "in": "path",
+            "description": "identifier of the plugin.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.PluginEnableRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.PluginEnableRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ManagedPluginDTO"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ManagedPluginDTO"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/manage/plugins/{pluginId}/install": {
+      "post": {
+        "tags": [
+          "Plugin"
+        ],
+        "summary": "Install one specific plugin",
+        "operationId": "installPlugin",
+        "parameters": [
+          {
+            "name": "pluginId",
+            "in": "path",
+            "description": "identifier of the plugin.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.InstallPluginRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.InstallPluginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ManagedPluginDTO"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ManagedPluginDTO"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/manage/plugins/{pluginId}/setting": {
+      "post": {
+        "tags": [
+          "Plugin"
+        ],
+        "summary": "Set an installed plugin",
+        "operationId": "pluginSetting",
+        "parameters": [
+          {
+            "name": "pluginId",
+            "in": "path",
+            "description": "identifier of the plugin.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ManagedPluginDTO"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ManagedPluginDTO"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/manage/plugins/{pluginId}/uninstall": {
+      "post": {
+        "tags": [
+          "Plugin"
+        ],
+        "summary": "Uninstall one specific plugin",
+        "operationId": "uninstallPlugin",
+        "parameters": [
+          {
+            "name": "pluginId",
+            "in": "path",
+            "description": "identifier of the plugin.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/payload_types": {
+      "get": {
+        "tags": [
+          "payload_types"
+        ],
+        "summary": "list application trigger payload types",
+        "operationId": "ListPayloadTypes",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {}
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/permissions": {
+      "get": {
+        "tags": [
+          "rbac"
+        ],
+        "summary": "list all platform level perm policies",
+        "operationId": "listPlatformPermissions",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/v1.PermissionBase"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/v1.PermissionBase"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "rbac"
+        ],
+        "summary": "create the platform perm policy",
+        "operationId": "createPlatformPermission",
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreatePermissionRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreatePermissionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PermissionBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PermissionBase"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/permissions/{permissionName}": {
+      "delete": {
+        "tags": [
+          "rbac"
+        ],
+        "summary": "delete a platform perm policy",
+        "operationId": "deletePlatformPermission",
+        "parameters": [
+          {
+            "name": "permissionName",
+            "in": "path",
+            "description": "identifier of the permission",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/pipelines": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "list pipelines",
+        "operationId": "listPipelines",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Fuzzy search based on name or description",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "projectName",
+            "in": "query",
+            "description": "query pipelines within a project",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "detailed",
+            "in": "query",
+            "description": "query pipelines with detail",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListPipelineResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListPipelineResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/plugins": {
+      "get": {
+        "tags": [
+          "Plugin"
+        ],
+        "summary": "List the enabled plugins",
+        "operationId": "listEnabledPlugins",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListPluginResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListPluginResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/plugins/{pluginId}": {
+      "get": {
+        "tags": [
+          "Plugin"
+        ],
+        "summary": "Detail an installed plugin",
+        "operationId": "detailPlugin",
+        "parameters": [
+          {
+            "name": "pluginId",
+            "in": "path",
+            "description": "identifier of the plugin.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PluginDTO"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PluginDTO"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/projects": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "list all projects",
+        "operationId": "listProjects",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListProjectResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListProjectResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "project"
+        ],
+        "summary": "create a project",
+        "operationId": "createProject",
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateProjectRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateProjectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ProjectBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ProjectBase"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/projects/{projectName}": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "detail a project",
+        "operationId": "detailProject",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ProjectBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ProjectBase"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "project"
+        ],
+        "summary": "update a project",
+        "operationId": "updateProject",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateProjectRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateProjectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ProjectBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ProjectBase"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "project"
+        ],
+        "summary": "delete a project",
+        "operationId": "deleteProject",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/config_templates": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "get the templates which are in a project",
+        "operationId": "getConfigTemplates",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "namespace",
+            "in": "query",
+            "description": "the namespace of the template",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListConfigTemplateResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListConfigTemplateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/config_templates/{templateName}": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "Detail a template",
+        "operationId": "getConfigTemplateByTemplateName",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "templateName",
+            "in": "path",
+            "description": "identifier of the config template",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "namespace",
+            "in": "query",
+            "description": "the name of the namespace",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ConfigTemplateDetail"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ConfigTemplateDetail"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/configs": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "get configs which are in a project",
+        "operationId": "getProjectConfigs",
+        "parameters": [
+          {
+            "name": "template",
+            "in": "query",
+            "description": "the template name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListConfigResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListConfigResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "project"
+        ],
+        "summary": "create a config in a project",
+        "operationId": "createProjectConfig",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateConfigRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateConfigRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Config"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Config"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/projects/{projectName}/configs/{configName}": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "detail a config in a project",
+        "operationId": "detailConfig",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "identifier of the config",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateConfigRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateConfigRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Config"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Config"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "put": {
+        "tags": [
+          "project"
+        ],
+        "summary": "update a config in a project",
+        "operationId": "updateProjectConfig",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "identifier of the config",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateConfigRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateConfigRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Config"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Config"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "project"
+        ],
+        "summary": "delete a config from a project",
+        "operationId": "deleteProjectConfig",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "identifier of the config",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/distributions": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "list the distribution jobs of the config",
+        "operationId": "listDistributions",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListConfigDistributionResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListConfigDistributionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "project"
+        ],
+        "summary": "apply the distribution job of the config",
+        "operationId": "applyDistribution",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateConfigDistributionRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateConfigDistributionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/projects/{projectName}/distributions/{distributionName}": {
+      "delete": {
+        "tags": [
+          "project"
+        ],
+        "summary": "delete a distribution job of the config",
+        "operationId": "deleteDistribution",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "distributionName",
+            "in": "path",
+            "description": "identifier of the distribution",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/permissions": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "list all project level perm policies",
+        "operationId": "listProjectPermissions",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/v1.PermissionBase"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/v1.PermissionBase"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "project"
+        ],
+        "summary": "create a project level perm policy",
+        "operationId": "createProjectPermission",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/v1.PermissionBase"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/v1.PermissionBase"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/permissions/{permissionName}": {
+      "delete": {
+        "tags": [
+          "project"
+        ],
+        "summary": "delete a project level perm policy",
+        "operationId": "deleteProjectPermission",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "permissionName",
+            "in": "path",
+            "description": "identifier of the permission",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/v1.PermissionBase"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/v1.PermissionBase"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines": {
+      "post": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "create pipeline",
+        "operationId": "createPipeline",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreatePipelineRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreatePipelineRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines/{pipelineName}": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "get pipeline",
+        "operationId": "getPipeline",
+        "parameters": [
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetPipelineResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetPipelineResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "update pipeline",
+        "operationId": "updatePipeline",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdatePipelineRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdatePipelineRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "delete pipeline",
+        "operationId": "deletePipeline",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineMetaResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineMetaResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines/{pipelineName}/contexts": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "list pipeline context values",
+        "operationId": "listContextValues",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListContextValueResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListContextValueResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "create pipeline context values",
+        "operationId": "createContextValue",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateContextValuesRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateContextValuesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Context"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Context"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines/{pipelineName}/contexts/{contextName}": {
+      "put": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "update pipeline context value",
+        "operationId": "updateContextValue",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "contextName",
+            "in": "path",
+            "description": "pipeline context name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateContextValuesRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateContextValuesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Context"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Context"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "delete pipeline context value",
+        "operationId": "deleteContextValue",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "contextName",
+            "in": "path",
+            "description": "pipeline context name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ContextNameResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ContextNameResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines/{pipelineName}/run": {
+      "post": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "run pipeline",
+        "operationId": "runPipeline",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.RunPipelineRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.RunPipelineRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineRun"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineRun"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines/{pipelineName}/runs": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "list pipeline runs",
+        "operationId": "listPipelineRuns",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "query identifier of the status",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListPipelineRunResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListPipelineRunResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines/{pipelineName}/runs/{runName}": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "get pipeline run",
+        "operationId": "getPipelineRun",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "runName",
+            "in": "path",
+            "description": "pipeline run name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineRunBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineRunBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "delete pipeline run",
+        "operationId": "deletePipelineRun",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "runName",
+            "in": "path",
+            "description": "pipeline run name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineRunMeta"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineRunMeta"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines/{pipelineName}/runs/{runName}/input": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "get pipeline run input",
+        "operationId": "getPipelineRunInput",
+        "parameters": [
+          {
+            "name": "step",
+            "in": "query",
+            "description": "query by specific step name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "runName",
+            "in": "path",
+            "description": "pipeline run name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetPipelineRunInputResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetPipelineRunInputResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines/{pipelineName}/runs/{runName}/log": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "get pipeline run log",
+        "operationId": "getPipelineRunLog",
+        "parameters": [
+          {
+            "name": "step",
+            "in": "query",
+            "description": "query by specific step name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "runName",
+            "in": "path",
+            "description": "pipeline run name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetPipelineRunLogResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetPipelineRunLogResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines/{pipelineName}/runs/{runName}/output": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "get pipeline run output",
+        "operationId": "getPipelineRunOutput",
+        "parameters": [
+          {
+            "name": "step",
+            "in": "query",
+            "description": "query by specific step name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "runName",
+            "in": "path",
+            "description": "pipeline run name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetPipelineRunOutputResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.GetPipelineRunOutputResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines/{pipelineName}/runs/{runName}/resume": {
+      "post": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "resume suspend pipeline run",
+        "operationId": "resumePipelineRun",
+        "parameters": [
+          {
+            "name": "step",
+            "in": "query",
+            "description": "resume from specific step name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "runName",
+            "in": "path",
+            "description": "pipeline run name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines/{pipelineName}/runs/{runName}/status": {
+      "get": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "get pipeline run status",
+        "operationId": "getPipelineRunStatus",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "runName",
+            "in": "path",
+            "description": "pipeline run name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1alpha1.WorkflowRunStatus"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1alpha1.WorkflowRunStatus"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines/{pipelineName}/runs/{runName}/stop": {
+      "post": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "stop pipeline run",
+        "operationId": "stopPipeline",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "runName",
+            "in": "path",
+            "description": "pipeline run name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineRunMeta"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.PipelineRunMeta"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/pipelines/{pipelineName}/runs/{runName}/terminate": {
+      "post": {
+        "tags": [
+          "pipeline"
+        ],
+        "summary": "resume suspend pipeline run",
+        "operationId": "terminatePipelineRun",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "project name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "pipelineName",
+            "in": "path",
+            "description": "pipeline name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "runName",
+            "in": "path",
+            "description": "pipeline run name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/providers": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "get providers which are in a project",
+        "operationId": "getProviders",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListTerraformProviderResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListTerraformProviderResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/roles": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "list all project level roles",
+        "operationId": "listProjectRoles",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListRolesResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListRolesResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "project"
+        ],
+        "summary": "create project level role",
+        "operationId": "createProjectRole",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateRoleRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.RoleBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.RoleBase"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/projects/{projectName}/roles/{roleName}": {
+      "put": {
+        "tags": [
+          "project"
+        ],
+        "summary": "update project level role",
+        "operationId": "updateProjectRole",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "roleName",
+            "in": "path",
+            "description": "identifier of the project role",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateRoleRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.RoleBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.RoleBase"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "project"
+        ],
+        "summary": "delete project level role",
+        "operationId": "deleteProjectRole",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "roleName",
+            "in": "path",
+            "description": "identifier of the project role",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/targets": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "get targets list belong to a project",
+        "operationId": "listProjectTargets",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/projects/{projectName}/users": {
+      "get": {
+        "tags": [
+          "project"
+        ],
+        "summary": "list all users belong to a project",
+        "operationId": "listProjectUser",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListProjectUsersResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListProjectUsersResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "project"
+        ],
+        "summary": "add a user to a project",
+        "operationId": "createProjectUser",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.AddProjectUserRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.AddProjectUserRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ProjectUserBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ProjectUserBase"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/projects/{projectName}/users/{userName}": {
+      "put": {
+        "tags": [
+          "project"
+        ],
+        "summary": "update a user from a project",
+        "operationId": "updateProjectUser",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userName",
+            "in": "path",
+            "description": "identifier of the project user",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateProjectUserRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateProjectUserRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ProjectUserBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ProjectUserBase"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "project"
+        ],
+        "summary": "delete a user from a project",
+        "operationId": "deleteProjectUser",
+        "parameters": [
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "identifier of the project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userName",
+            "in": "path",
+            "description": "identifier of the project user",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateProjectUserRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateProjectUserRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/query": {
+      "get": {
+        "tags": [
+          "velaQL"
+        ],
+        "summary": "use velaQL to query resource status",
+        "operationId": "queryView",
+        "parameters": [
+          {
+            "name": "velaql",
+            "in": "query",
+            "description": "velaql query statement",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.VelaQLViewResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.VelaQLViewResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/repository/chart/values": {
+      "get": {
+        "tags": [
+          "repository",
+          "helm"
+        ],
+        "summary": "get chart value",
+        "operationId": "chartValues",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "query",
+            "description": "the config project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "chart",
+            "in": "query",
+            "description": "helm chart",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "description": "helm chart version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "repoUrl",
+            "in": "query",
+            "description": "helm repository url",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "repoType",
+            "in": "query",
+            "description": "helm repository type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secretName",
+            "in": "query",
+            "description": "secret of the repo",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/repository/chart/versions": {
+      "get": {
+        "tags": [
+          "repository",
+          "helm"
+        ],
+        "summary": "list versions",
+        "operationId": "listVersionsFromQuery",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "query",
+            "description": "the config project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "chart",
+            "in": "query",
+            "description": "helm chart",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "repoUrl",
+            "in": "query",
+            "description": "helm repository url",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secretName",
+            "in": "query",
+            "description": "secret of the repo",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ChartVersionListResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ChartVersionListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/repository/chart_repos": {
+      "get": {
+        "tags": [
+          "repository",
+          "helm"
+        ],
+        "summary": "list chart repo",
+        "operationId": "listRepo",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "query",
+            "description": "the config project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/repository/charts": {
+      "get": {
+        "tags": [
+          "repository",
+          "helm"
+        ],
+        "summary": "list charts",
+        "operationId": "listCharts",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "query",
+            "description": "the config project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "repoUrl",
+            "in": "query",
+            "description": "helm repository url",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secretName",
+            "in": "query",
+            "description": "secret of the repo",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/repository/charts/{chart}/versions": {
+      "get": {
+        "tags": [
+          "repository",
+          "helm"
+        ],
+        "summary": "list versions",
+        "operationId": "listChartVersions",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "query",
+            "description": "the config project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "chart",
+            "in": "path",
+            "description": "identifier of the helm chart",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "repoUrl",
+            "in": "query",
+            "description": "helm repository url",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secretName",
+            "in": "query",
+            "description": "secret of the repo",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ChartVersionListResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ChartVersionListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/v1/repository/charts/{chart}/versions/{version}/values": {
+      "get": {
+        "tags": [
+          "repository",
+          "helm"
+        ],
+        "summary": "get chart value",
+        "operationId": "getChartValues",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "query",
+            "description": "the config project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "chart",
+            "in": "path",
+            "description": "identifier of the helm chart",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "in": "path",
+            "description": "version of the helm chart",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "repoUrl",
+            "in": "query",
+            "description": "helm repository url",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secretName",
+            "in": "query",
+            "description": "secret of the repo",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Properties"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.Properties"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/v1/repository/image/info": {
+      "get": {
+        "tags": [
+          "repository",
+          "helm"
+        ],
+        "summary": "get the oci repos",
+        "operationId": "getImageInfo",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "query",
+            "description": "the config project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "the image name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "secretName",
+            "in": "query",
+            "description": "the secret name of the image repository",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ImageInfo"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ImageInfo"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/repository/image/repos": {
+      "get": {
+        "tags": [
+          "repository",
+          "helm"
+        ],
+        "summary": "get the oci repos",
+        "operationId": "getImageRepos",
+        "parameters": [
+          {
+            "name": "project",
+            "in": "query",
+            "description": "the config project",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListImageRegistryResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListImageRegistryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/roles": {
+      "get": {
+        "tags": [
+          "rbac"
+        ],
+        "summary": "list all platform level roles",
+        "operationId": "listPlatformRoles",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListRolesResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListRolesResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "rbac"
+        ],
+        "summary": "create platform level role",
+        "operationId": "createPlatformRole",
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateRoleRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.RoleBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.RoleBase"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/roles/{roleName}": {
+      "put": {
+        "tags": [
+          "rbac"
+        ],
+        "summary": "update platform level role",
+        "operationId": "updatePlatformRole",
+        "parameters": [
+          {
+            "name": "roleName",
+            "in": "path",
+            "description": "identifier of the role",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateRoleRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.RoleBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.RoleBase"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "rbac"
+        ],
+        "summary": "update platform level role",
+        "operationId": "deletePlatformRole",
+        "parameters": [
+          {
+            "name": "roleName",
+            "in": "path",
+            "description": "identifier of the role",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/system_info": {
+      "get": {
+        "tags": [
+          "systemInfo"
+        ],
+        "operationId": "getSystemInfo",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SystemInfoResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SystemInfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "systemInfo"
+        ],
+        "operationId": "updateSystemInfo",
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.SystemInfoRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.SystemInfoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SystemInfoResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SystemInfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/targets": {
+      "get": {
+        "tags": [
+          "Target"
+        ],
+        "summary": "list Target",
+        "operationId": "listTargets",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page for paging",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "PageSize for paging",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "project",
+            "in": "query",
+            "description": "list targets by project name",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListTargetResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListTargetResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Target"
+        ],
+        "summary": "create Target",
+        "operationId": "createTarget",
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateTargetRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateTargetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "create success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailTargetResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailTargetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "create failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/targets/{targetName}": {
+      "get": {
+        "tags": [
+          "Target"
+        ],
+        "summary": "detail Target",
+        "operationId": "detailTarget",
+        "parameters": [
+          {
+            "name": "targetName",
+            "in": "path",
+            "description": "identifier of the Target.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "create success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailTargetResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailTargetResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Target"
+        ],
+        "summary": "update application Target config",
+        "operationId": "updateTarget",
+        "parameters": [
+          {
+            "name": "targetName",
+            "in": "path",
+            "description": "identifier of the Target",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateTargetRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateTargetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailTargetResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailTargetResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "Target"
+        ],
+        "summary": "delete Target",
+        "operationId": "deleteTarget",
+        "parameters": [
+          {
+            "name": "targetName",
+            "in": "path",
+            "description": "identifier of the Target",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SimpleResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SimpleResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/api/v1/users": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "list users",
+        "operationId": "listUser",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "query the page number",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "query the page size number",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "fuzzy search based on name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "description": "fuzzy search based on email",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "alias",
+            "in": "query",
+            "description": "fuzzy search based on alias",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListUserResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ListUserResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "create a user",
+        "operationId": "createUser",
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateUserRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.CreateUserRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.UserBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.UserBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/api/v1/users/{username}": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "get user detail",
+        "operationId": "detailUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "identifier of a user",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailUserResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.DetailUserResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "users"
+        ],
+        "summary": "update a user's alias or password",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "identifier of a user",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateUserRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.UpdateUserRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.UserBase"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.UserBase"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "users"
+        ],
+        "summary": "delete a user",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "identifier of a user",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/{username}/disable": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "disable a user",
+        "operationId": "disableUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "identifier of a user",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/{username}/enable": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "enable a user",
+        "operationId": "enableUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "identifier of a user",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.EmptyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/webhook/{token}": {
+      "post": {
+        "tags": [
+          "webhook"
+        ],
+        "summary": "handle application webhook request",
+        "operationId": "handleApplicationWebhook",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "description": "webhook token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.HandleApplicationTriggerWebhookRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.HandleApplicationTriggerWebhookRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationDeployResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationDeployResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/v1/namespaces/{namespace}/applications/{appname}": {
+      "get": {
+        "tags": [
+          "oam_application"
+        ],
+        "summary": "get the specified oam application in the specified namespace",
+        "operationId": "getApplication",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "identifier of the namespace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "appname",
+            "in": "path",
+            "description": "identifier of the oam application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.ApplicationResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "oam_application"
+        ],
+        "summary": "create or update oam application in the specified namespace",
+        "operationId": "createOrUpdateApplication",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "identifier of the namespace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "appname",
+            "in": "path",
+            "description": "identifier of the oam application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dryRun",
+            "in": "query",
+            "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "publishVersion",
+            "in": "query",
+            "description": "The publish version for deploying application.if no specified, {application name}-v{the number of times it was published} (e.g.: demo-app-v13) will be used. the workflow record will use this value as the record identifier, so please ensure that this value is not duplicated if you specify it, otherwise the request will report an error",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.ApplicationRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/v1.ApplicationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {}
+          }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": [
+          "oam_application"
+        ],
+        "summary": "delete oam application in the specified namespace",
+        "operationId": "deleteOAMApplication",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "identifier of the namespace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "appname",
+            "in": "path",
+            "description": "identifier of the oam application",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/view/cloudshell": {
+      "get": {
+        "tags": [
+          "cloudshell"
+        ],
+        "summary": "prepare the user's cloud shell environment",
+        "operationId": "proxy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SimpleResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SimpleResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/view/cloudshell/{subpath}": {
+      "get": {
+        "tags": [
+          "cloudshell"
+        ],
+        "summary": "prepare the user's cloud shell environment",
+        "operationId": "proxyPath",
+        "parameters": [
+          {
+            "name": "subpath",
+            "in": "path",
+            "description": "subpath",
+            "required": true,
+            "schema": {
+              "pattern": "*",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SimpleResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/v1.SimpleResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/bcode.Bcode"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bummer, something went wrong",
+            "content": {}
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    },
+    "schemas": {
+      "*schema.UIParameter": {
+        "type": "object"
+      },
+      "*v1.ApplicationTriggerBase": {
+        "type": "object"
+      },
+      "*v1.Config": {
+        "type": "object"
+      },
+      "*v1.EmptyResponse": {
+        "type": "object"
+      },
+      "*v1.UpdateConfigRequest": {
+        "type": "object"
+      },
+      "addon.Dependency": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "addon.DeployTo": {
+        "required": [
+          "disableControlPlane",
+          "runtimeCluster"
+        ],
+        "type": "object",
+        "properties": {
+          "disableControlPlane": {
+            "type": "boolean"
+          },
+          "runtimeCluster": {
+            "type": "boolean"
+          }
+        }
+      },
+      "addon.GitAddonSource": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "addon.GiteeAddonSource": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "addon.GitlabAddonSource": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "addon.HelmSource": {
+        "type": "object",
+        "properties": {
+          "insecureSkipTLS": {
+            "type": "boolean"
+          },
+          "password": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      },
+      "addon.Meta": {
+        "required": [
+          "description",
+          "icon",
+          "invisible",
+          "name",
+          "version"
+        ],
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "dependencies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/addon.Dependency"
+            }
+          },
+          "deployTo": {
+            "$ref": "#/components/schemas/addon.DeployTo"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "invisible": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "needNamespace": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "system": {
+            "$ref": "#/components/schemas/addon.SystemRequirements"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "url": {
+            "type": "string"
+          },
+          "uxPlugins": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "addon.OSSAddonSource": {
+        "required": [
+          "bucket",
+          "end_point",
+          "path"
+        ],
+        "type": "object",
+        "properties": {
+          "bucket": {
+            "type": "string"
+          },
+          "end_point": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        }
+      },
+      "addon.SystemRequirements": {
+        "type": "object",
+        "properties": {
+          "kubernetes": {
+            "type": "string"
+          },
+          "vela": {
+            "type": "string"
+          }
+        }
+      },
+      "bcode.Bcode": {
+        "required": [
+          "BusinessCode",
+          "Message"
+        ],
+        "type": "object",
+        "properties": {
+          "BusinessCode": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "Message": {
+            "type": "string"
+          }
+        }
+      },
+      "chart.Dependency": {
+        "required": [
+          "name",
+          "repository"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "condition": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "import-values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/chart.Dependency.import-values"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "repository": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "chart.Dependency.import-values": {
+        "type": "object"
+      },
+      "chart.Maintainer": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "chart.Metadata": {
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "apiVersion": {
+            "type": "string"
+          },
+          "appVersion": {
+            "type": "string"
+          },
+          "condition": {
+            "type": "string"
+          },
+          "dependencies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/chart.Dependency"
+            }
+          },
+          "deprecated": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "home": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "kubeVersion": {
+            "type": "string"
+          },
+          "maintainers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/chart.Maintainer"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "cloudprovider.CloudCluster": {
+        "required": [
+          "apiServerURL",
+          "dashboardURL",
+          "id",
+          "labels",
+          "name",
+          "provider",
+          "regionID",
+          "status",
+          "type",
+          "vpcID",
+          "zone",
+          "zoneID"
+        ],
+        "type": "object",
+        "properties": {
+          "apiServerURL": {
+            "type": "string"
+          },
+          "dashboardURL": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "regionID": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "vpcID": {
+            "type": "string"
+          },
+          "zone": {
+            "type": "string"
+          },
+          "zoneID": {
+            "type": "string"
+          }
+        }
+      },
+      "common.AppStatus": {
+        "type": "object",
+        "properties": {
+          "appliedResources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/common.ClusterObjectReference"
+            }
+          },
+          "components": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ObjectReference"
+            }
+          },
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/condition.Condition"
+            }
+          },
+          "latestRevision": {
+            "$ref": "#/components/schemas/common.Revision"
+          },
+          "observedGeneration": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "policy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/common.PolicyStatus"
+            }
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/common.ApplicationComponentStatus"
+            }
+          },
+          "status": {
+            "type": "string"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/common.WorkflowStatus"
+          }
+        }
+      },
+      "common.ApplicationComponent": {
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "externalRevision": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.InputItem"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.OutputItem"
+            }
+          },
+          "properties": {
+            "type": "string"
+          },
+          "scopes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "traits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/common.ApplicationTrait"
+            }
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "common.ApplicationComponentStatus": {
+        "required": [
+          "healthy",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "cluster": {
+            "type": "string"
+          },
+          "env": {
+            "type": "string"
+          },
+          "healthy": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ObjectReference"
+            }
+          },
+          "traits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/common.ApplicationTraitStatus"
+            }
+          },
+          "workloadDefinition": {
+            "$ref": "#/components/schemas/common.WorkloadGVK"
+          }
+        }
+      },
+      "common.ApplicationTrait": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "properties": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "common.ApplicationTraitStatus": {
+        "required": [
+          "healthy",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "healthy": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "common.CUE": {
+        "required": [
+          "template"
+        ],
+        "type": "object",
+        "properties": {
+          "template": {
+            "type": "string"
+          }
+        }
+      },
+      "common.ChildResourceKind": {
+        "required": [
+          "apiVersion",
+          "kind"
+        ],
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "selector": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "common.ClusterObjectReference": {
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "type": "string",
+            "description": "API version of the referent."
+          },
+          "cluster": {
+            "type": "string"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "fieldPath": {
+            "type": "string",
+            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object."
+          },
+          "kind": {
+            "type": "string",
+            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+          },
+          "namespace": {
+            "type": "string",
+            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+          },
+          "resourceVersion": {
+            "type": "string",
+            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency"
+          },
+          "uid": {
+            "type": "string",
+            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids"
+          }
+        },
+        "description": "ObjectReference contains enough information to let you inspect or modify the referred object."
+      },
+      "common.DefinitionReference": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "common.HTTPOption": {
+        "type": "object",
+        "properties": {
+          "caFile": {
+            "type": "string"
+          },
+          "certFile": {
+            "type": "string"
+          },
+          "insecureSkipTLS": {
+            "type": "boolean"
+          },
+          "keyFile": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      },
+      "common.PolicyStatus": {
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "common.Revision": {
+        "required": [
+          "name",
+          "revision"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "revision": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "revisionHash": {
+            "type": "string"
+          }
+        }
+      },
+      "common.Schematic": {
+        "type": "object",
+        "properties": {
+          "cue": {
+            "$ref": "#/components/schemas/common.CUE"
+          },
+          "terraform": {
+            "$ref": "#/components/schemas/common.Terraform"
+          }
+        }
+      },
+      "common.Status": {
+        "type": "object",
+        "properties": {
+          "customStatus": {
+            "type": "string"
+          },
+          "healthPolicy": {
+            "type": "string"
+          }
+        }
+      },
+      "common.Terraform": {
+        "required": [
+          "configuration"
+        ],
+        "type": "object",
+        "properties": {
+          "configuration": {
+            "type": "string"
+          },
+          "customRegion": {
+            "type": "string"
+          },
+          "deleteResource": {
+            "type": "boolean"
+          },
+          "gitCredentialsSecretReference": {
+            "$ref": "#/components/schemas/v1.SecretReference"
+          },
+          "path": {
+            "type": "string"
+          },
+          "providerRef": {
+            "$ref": "#/components/schemas/types.Reference"
+          },
+          "type": {
+            "type": "string"
+          },
+          "writeConnectionSecretToRef": {
+            "$ref": "#/components/schemas/types.SecretReference"
+          }
+        }
+      },
+      "common.WorkflowStatus": {
+        "required": [
+          "finished",
+          "mode",
+          "suspend",
+          "terminated"
+        ],
+        "type": "object",
+        "properties": {
+          "appRevision": {
+            "type": "string"
+          },
+          "contextBackend": {
+            "$ref": "#/components/schemas/v1.ObjectReference"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "finished": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.WorkflowStepStatus"
+            }
+          },
+          "suspend": {
+            "type": "boolean"
+          },
+          "suspendState": {
+            "type": "string"
+          },
+          "terminated": {
+            "type": "boolean"
+          }
+        }
+      },
+      "common.WorkloadGVK": {
+        "required": [
+          "apiVersion",
+          "kind"
+        ],
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          }
+        }
+      },
+      "common.WorkloadTypeDescriptor": {
+        "type": "object",
+        "properties": {
+          "definition": {
+            "$ref": "#/components/schemas/common.WorkloadGVK"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "condition.Condition": {
+        "required": [
+          "lastTransitionTime",
+          "reason",
+          "status",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "lastTransitionTime": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "condition.ConditionedStatus": {
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/condition.Condition"
+            }
+          }
+        }
+      },
+      "config.ClusterTarget": {
+        "required": [
+          "clusterName",
+          "namespace"
+        ],
+        "type": "object",
+        "properties": {
+          "clusterName": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          }
+        }
+      },
+      "config.ClusterTargetStatus": {
+        "required": [
+          "application",
+          "clusterName",
+          "message",
+          "namespace",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "application": {
+            "$ref": "#/components/schemas/config.NamespacedName"
+          },
+          "clusterName": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "config.Distribution": {
+        "required": [
+          "application",
+          "configs",
+          "createdTime",
+          "name",
+          "namespace",
+          "status",
+          "targets"
+        ],
+        "type": "object",
+        "properties": {
+          "application": {
+            "$ref": "#/components/schemas/types.NamespacedName"
+          },
+          "configs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/config.NamespacedName"
+            }
+          },
+          "createdTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/common.AppStatus"
+          },
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/config.ClusterTarget"
+            }
+          }
+        }
+      },
+      "config.NamespacedName": {
+        "required": [
+          "name",
+          "namespace"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          }
+        }
+      },
+      "map[string]interface {}": {
+        "type": "object"
+      },
+      "map[string]string": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "model.ApplicationComponent": {
+        "required": [
+          "alias",
+          "appPrimaryKey",
+          "createTime",
+          "creator",
+          "main",
+          "name",
+          "type",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "appPrimaryKey": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "externalRevision": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.InputItem"
+            }
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "main": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.OutputItem"
+            }
+          },
+          "properties": {
+            "$ref": "#/components/schemas/model.JSONStruct"
+          },
+          "scopes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "traits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.ApplicationTrait"
+            }
+          },
+          "type": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "workloadType": {
+            "$ref": "#/components/schemas/common.WorkloadTypeDescriptor"
+          }
+        }
+      },
+      "model.ApplicationRevision": {
+        "required": [
+          "appPrimaryKey",
+          "createTime",
+          "deployUser",
+          "envName",
+          "note",
+          "reason",
+          "revisionCRName",
+          "status",
+          "triggerType",
+          "updateTime",
+          "version",
+          "workflowName"
+        ],
+        "type": "object",
+        "properties": {
+          "appPrimaryKey": {
+            "type": "string"
+          },
+          "applyAppConfig": {
+            "type": "string"
+          },
+          "codeInfo": {
+            "$ref": "#/components/schemas/model.CodeInfo"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deployUser": {
+            "type": "string"
+          },
+          "envName": {
+            "type": "string"
+          },
+          "imageInfo": {
+            "$ref": "#/components/schemas/model.ImageInfo"
+          },
+          "note": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "revisionCRName": {
+            "type": "string"
+          },
+          "rollbackVersion": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "triggerType": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "version": {
+            "type": "string"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        }
+      },
+      "model.ApplicationTrait": {
+        "required": [
+          "alias",
+          "createTime",
+          "description",
+          "type",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/model.JSONStruct"
+          },
+          "type": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "model.BaseModel": {
+        "required": [
+          "createTime",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "model.Cluster": {
+        "required": [
+          "alias",
+          "apiServerURL",
+          "createTime",
+          "dashboardURL",
+          "description",
+          "icon",
+          "kubeConfig",
+          "kubeConfigSecret",
+          "labels",
+          "name",
+          "provider",
+          "reason",
+          "status",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "apiServerURL": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dashboardURL": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "kubeConfig": {
+            "type": "string"
+          },
+          "kubeConfigSecret": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/model.ProviderInfo"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "model.CodeInfo": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "type": "string"
+          },
+          "commit": {
+            "type": "string"
+          },
+          "user": {
+            "type": "string"
+          }
+        }
+      },
+      "model.ImageInfo": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "repository": {
+            "$ref": "#/components/schemas/model.ImageRepository"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/model.ImageResource"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "model.ImageRepository": {
+        "required": [
+          "fullName",
+          "name",
+          "namespace",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fullName": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "model.ImageResource": {
+        "required": [
+          "digest",
+          "tag",
+          "url"
+        ],
+        "type": "object",
+        "properties": {
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "digest": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "model.JSONStruct": {
+        "type": "object"
+      },
+      "model.ProjectRef": {
+        "required": [
+          "name",
+          "roles"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "model.ProviderInfo": {
+        "required": [
+          "clusterID",
+          "labels",
+          "provider"
+        ],
+        "type": "object",
+        "properties": {
+          "clusterID": {
+            "type": "string"
+          },
+          "clusterName": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "provider": {
+            "type": "string"
+          },
+          "regionID": {
+            "type": "string"
+          },
+          "vpcID": {
+            "type": "string"
+          },
+          "zone": {
+            "type": "string"
+          },
+          "zoneID": {
+            "type": "string"
+          }
+        }
+      },
+      "model.StepStatus": {
+        "required": [
+          "alias",
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "firstExecuteTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastExecuteTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "message": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phase": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "model.Value": {
+        "required": [
+          "key",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "model.WorkflowSpec": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowExecuteMode"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.WorkflowStep"
+            }
+          }
+        }
+      },
+      "model.WorkflowStep": {
+        "required": [
+          "alias",
+          "dependsOn",
+          "description",
+          "name",
+          "orderIndex",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "if": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.InputItem"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowStepMeta"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "orderIndex": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.OutputItem"
+            }
+          },
+          "properties": {
+            "$ref": "#/components/schemas/model.JSONStruct"
+          },
+          "subSteps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.WorkflowStepBase"
+            }
+          },
+          "timeout": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "model.WorkflowStepBase": {
+        "required": [
+          "alias",
+          "dependsOn",
+          "description",
+          "name",
+          "orderIndex",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "if": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.InputItem"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowStepMeta"
+          },
+          "name": {
+            "type": "string"
+          },
+          "orderIndex": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.OutputItem"
+            }
+          },
+          "properties": {
+            "$ref": "#/components/schemas/model.JSONStruct"
+          },
+          "timeout": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "model.WorkflowStepStatus": {
+        "required": [
+          "alias",
+          "id",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "firstExecuteTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastExecuteTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "message": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phase": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "subSteps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.StepStatus"
+            }
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "repo.ChartVersion": {
+        "required": [
+          "Metadata",
+          "urls"
+        ],
+        "type": "object",
+        "properties": {
+          "Metadata": {
+            "$ref": "#/components/schemas/chart.Metadata"
+          },
+          "checksum": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "digest": {
+            "type": "string"
+          },
+          "engine": {
+            "type": "string"
+          },
+          "removed": {
+            "type": "boolean"
+          },
+          "tillerVersion": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "urls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "schema.Condition": {
+        "required": [
+          "jsonKey",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string"
+          },
+          "jsonKey": {
+            "type": "string"
+          },
+          "op": {
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/components/schemas/schema.Condition.value"
+          }
+        }
+      },
+      "schema.Condition.value": {
+        "type": "object"
+      },
+      "schema.GroupOption": {
+        "required": [
+          "keys",
+          "label"
+        ],
+        "type": "object",
+        "properties": {
+          "keys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "label": {
+            "type": "string"
+          }
+        }
+      },
+      "schema.Option": {
+        "required": [
+          "label",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/components/schemas/schema.Option.value"
+          }
+        }
+      },
+      "schema.Option.value": {
+        "type": "object"
+      },
+      "schema.Style": {
+        "required": [
+          "colSpan"
+        ],
+        "type": "object",
+        "properties": {
+          "colSpan": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "schema.UIParameter": {
+        "required": [
+          "description",
+          "jsonKey",
+          "label",
+          "sort",
+          "uiType"
+        ],
+        "type": "object",
+        "properties": {
+          "additional": {
+            "type": "boolean"
+          },
+          "additionalParameter": {
+            "$ref": "#/components/schemas/schema.UIParameter"
+          },
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/schema.Condition"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "disable": {
+            "type": "boolean"
+          },
+          "jsonKey": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "sort": {
+            "type": "integer",
+            "format": "integer"
+          },
+          "style": {
+            "$ref": "#/components/schemas/schema.Style"
+          },
+          "subParameterGroupOption": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/schema.GroupOption"
+            }
+          },
+          "subParameters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/schema.UIParameter"
+            }
+          },
+          "uiType": {
+            "type": "string"
+          },
+          "validate": {
+            "$ref": "#/components/schemas/schema.Validate"
+          }
+        }
+      },
+      "schema.Validate": {
+        "required": [
+          "immutable"
+        ],
+        "type": "object",
+        "properties": {
+          "defaultValue": {
+            "$ref": "#/components/schemas/schema.Validate.defaultValue"
+          },
+          "immutable": {
+            "type": "boolean"
+          },
+          "max": {
+            "type": "number",
+            "format": "double"
+          },
+          "maxLength": {
+            "type": "integer",
+            "format": "integer"
+          },
+          "min": {
+            "type": "number",
+            "format": "double"
+          },
+          "minLength": {
+            "type": "integer",
+            "format": "integer"
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/schema.Option"
+            }
+          },
+          "pattern": {
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          }
+        }
+      },
+      "schema.Validate.defaultValue": {
+        "type": "object"
+      },
+      "types.BuildInfo": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "type": "string"
+          },
+          "hash": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "time": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "types.Header": {
+        "required": [
+          "name",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "types.Includes": {
+        "required": [
+          "icon",
+          "label",
+          "name",
+          "relatedRoute",
+          "to",
+          "type",
+          "workspace"
+        ],
+        "type": "object",
+        "properties": {
+          "catalog": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "permission": {
+            "$ref": "#/components/schemas/types.Permission"
+          },
+          "relatedRoute": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "to": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "workspace": {
+            "$ref": "#/components/schemas/types.Workspace"
+          }
+        }
+      },
+      "types.Info": {
+        "required": [
+          "author",
+          "build",
+          "description",
+          "links",
+          "logos",
+          "screenshots",
+          "updated",
+          "version"
+        ],
+        "type": "object",
+        "properties": {
+          "author": {
+            "$ref": "#/components/schemas/types.InfoLink"
+          },
+          "build": {
+            "$ref": "#/components/schemas/types.BuildInfo"
+          },
+          "description": {
+            "type": "string"
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/types.InfoLink"
+            }
+          },
+          "logos": {
+            "$ref": "#/components/schemas/types.Logos"
+          },
+          "screenshots": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/types.Screenshots"
+            }
+          },
+          "updated": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "types.InfoLink": {
+        "required": [
+          "name",
+          "url"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "types.JSONData": {
+        "required": [
+          "backend",
+          "backendService",
+          "backendType",
+          "category",
+          "id",
+          "includes",
+          "info",
+          "name",
+          "proxy",
+          "subType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "authSecret": {
+            "$ref": "#/components/schemas/types.KubernetesSecret"
+          },
+          "authType": {
+            "type": "string"
+          },
+          "backend": {
+            "type": "boolean"
+          },
+          "backendService": {
+            "$ref": "#/components/schemas/types.KubernetesService"
+          },
+          "backendType": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "includes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/types.Includes"
+            }
+          },
+          "info": {
+            "$ref": "#/components/schemas/types.Info"
+          },
+          "kubePermissions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.PolicyRule"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "proxy": {
+            "type": "boolean"
+          },
+          "requirement": {
+            "$ref": "#/components/schemas/types.Requirement"
+          },
+          "routes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/types.Route"
+            }
+          },
+          "subType": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "types.KubernetesSecret": {
+        "required": [
+          "name",
+          "namespace"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          }
+        }
+      },
+      "types.KubernetesService": {
+        "required": [
+          "name",
+          "namespace",
+          "port"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "types.Logos": {
+        "required": [
+          "large",
+          "small"
+        ],
+        "type": "object",
+        "properties": {
+          "large": {
+            "type": "string"
+          },
+          "small": {
+            "type": "string"
+          }
+        }
+      },
+      "types.NamespacedName": {
+        "required": [
+          "Name",
+          "Namespace"
+        ],
+        "type": "object",
+        "properties": {
+          "Name": {
+            "type": "string"
+          },
+          "Namespace": {
+            "type": "string"
+          }
+        }
+      },
+      "types.Permission": {
+        "required": [
+          "action",
+          "resource"
+        ],
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "string"
+          }
+        }
+      },
+      "types.Reference": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          }
+        }
+      },
+      "types.Requirement": {
+        "required": [
+          "velauxVersion"
+        ],
+        "type": "object",
+        "properties": {
+          "velauxVersion": {
+            "type": "string"
+          }
+        }
+      },
+      "types.Route": {
+        "required": [
+          "method",
+          "path"
+        ],
+        "type": "object",
+        "properties": {
+          "headers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/types.Header"
+            }
+          },
+          "method": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "permission": {
+            "$ref": "#/components/schemas/types.Permission"
+          },
+          "resourceMap": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "types.Screenshots": {
+        "required": [
+          "name",
+          "path"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        }
+      },
+      "types.SecretReference": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          }
+        }
+      },
+      "types.Workspace": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.AccessKeyRequest": {
+        "required": [
+          "accessKeyID",
+          "accessKeySecret"
+        ],
+        "type": "object",
+        "properties": {
+          "accessKeyID": {
+            "type": "string"
+          },
+          "accessKeySecret": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.AddProjectUserRequest": {
+        "required": [
+          "userName",
+          "userRoles"
+        ],
+        "type": "object",
+        "properties": {
+          "userName": {
+            "type": "string"
+          },
+          "userRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.AddonBaseStatus": {
+        "required": [
+          "name",
+          "phase"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "phase": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.AddonDefinition": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.AddonInfo": {
+        "required": [
+          "Meta",
+          "registryName"
+        ],
+        "type": "object",
+        "properties": {
+          "Meta": {
+            "$ref": "#/components/schemas/addon.Meta"
+          },
+          "registryName": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.AddonRegistry": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "git": {
+            "$ref": "#/components/schemas/addon.GitAddonSource"
+          },
+          "gitee": {
+            "$ref": "#/components/schemas/addon.GiteeAddonSource"
+          },
+          "gitlab": {
+            "$ref": "#/components/schemas/addon.GitlabAddonSource"
+          },
+          "helm": {
+            "$ref": "#/components/schemas/addon.HelmSource"
+          },
+          "name": {
+            "type": "string"
+          },
+          "oss": {
+            "$ref": "#/components/schemas/addon.OSSAddonSource"
+          }
+        }
+      },
+      "v1.AddonStatusResponse": {
+        "required": [
+          "args",
+          "name",
+          "phase"
+        ],
+        "type": "object",
+        "properties": {
+          "allClusters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.NameAlias"
+            }
+          },
+          "appStatus": {
+            "$ref": "#/components/schemas/common.AppStatus"
+          },
+          "args": {
+            "type": "object",
+            "properties": {}
+          },
+          "clusters": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/v1.AddonStatusResponse.clusters"
+            }
+          },
+          "enabling_progress": {
+            "$ref": "#/components/schemas/v1.EnablingProgress"
+          },
+          "installedVersion": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phase": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.AddonStatusResponse.clusters": {
+        "type": "object"
+      },
+      "v1.AdminConfiguredResponse": {
+        "required": [
+          "configured"
+        ],
+        "type": "object",
+        "properties": {
+          "configured": {
+            "type": "boolean"
+          }
+        }
+      },
+      "v1.AppCompareReq": {
+        "type": "object",
+        "properties": {
+          "compareLatestWithRunning": {
+            "$ref": "#/components/schemas/v1.CompareLatestWithRunningOption"
+          },
+          "compareRevisionWithLatest": {
+            "$ref": "#/components/schemas/v1.CompareRevisionWithLatestOption"
+          },
+          "compareRevisionWithRunning": {
+            "$ref": "#/components/schemas/v1.CompareRevisionWithRunningOption"
+          }
+        }
+      },
+      "v1.AppCompareResponse": {
+        "required": [
+          "baseAppYAML",
+          "diffReport",
+          "isDiff",
+          "targetAppYAML"
+        ],
+        "type": "object",
+        "properties": {
+          "baseAppYAML": {
+            "type": "string"
+          },
+          "diffReport": {
+            "type": "string"
+          },
+          "isDiff": {
+            "type": "boolean"
+          },
+          "targetAppYAML": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.AppDryRunReq": {
+        "required": [
+          "dryRunType",
+          "env",
+          "version",
+          "workflow"
+        ],
+        "type": "object",
+        "properties": {
+          "dryRunType": {
+            "type": "string"
+          },
+          "env": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "workflow": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.AppDryRunResponse": {
+        "required": [
+          "success",
+          "yaml"
+        ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "success": {
+            "type": "boolean"
+          },
+          "yaml": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.AppResetResponse": {
+        "required": [
+          "isReset"
+        ],
+        "type": "object",
+        "properties": {
+          "isReset": {
+            "type": "boolean"
+          }
+        }
+      },
+      "v1.ApplicationBase": {
+        "required": [
+          "alias",
+          "createTime",
+          "description",
+          "icon",
+          "name",
+          "project",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/v1.ProjectBase"
+          },
+          "readOnly": {
+            "type": "boolean"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "v1.ApplicationDeployRequest": {
+        "required": [
+          "force",
+          "note",
+          "triggerType",
+          "workflowName"
+        ],
+        "type": "object",
+        "properties": {
+          "codeInfo": {
+            "$ref": "#/components/schemas/model.CodeInfo"
+          },
+          "force": {
+            "type": "boolean"
+          },
+          "imageInfo": {
+            "$ref": "#/components/schemas/model.ImageInfo"
+          },
+          "note": {
+            "type": "string"
+          },
+          "triggerType": {
+            "type": "string"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.ApplicationDeployResponse": {
+        "required": [
+          "createTime",
+          "envName",
+          "note",
+          "record",
+          "status",
+          "triggerType",
+          "version",
+          "workflowName"
+        ],
+        "type": "object",
+        "properties": {
+          "codeInfo": {
+            "$ref": "#/components/schemas/model.CodeInfo"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deployUser": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          },
+          "envName": {
+            "type": "string"
+          },
+          "imageInfo": {
+            "$ref": "#/components/schemas/model.ImageInfo"
+          },
+          "note": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "record": {
+            "$ref": "#/components/schemas/v1.WorkflowRecordBase"
+          },
+          "status": {
+            "type": "string"
+          },
+          "triggerType": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.ApplicationRequest": {
+        "required": [
+          "components"
+        ],
+        "type": "object",
+        "properties": {
+          "components": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/common.ApplicationComponent"
+            }
+          },
+          "policies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1beta1.AppPolicy"
+            }
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/v1beta1.Workflow"
+          }
+        }
+      },
+      "v1.ApplicationResourceInfo": {
+        "required": [
+          "componentNum"
+        ],
+        "type": "object",
+        "properties": {
+          "componentNum": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "v1.ApplicationResponse": {
+        "required": [
+          "apiVersion",
+          "kind",
+          "spec",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "spec": {
+            "$ref": "#/components/schemas/v1beta1.ApplicationSpec"
+          },
+          "status": {
+            "$ref": "#/components/schemas/common.AppStatus"
+          }
+        }
+      },
+      "v1.ApplicationRevisionBase": {
+        "required": [
+          "createTime",
+          "envName",
+          "note",
+          "status",
+          "triggerType",
+          "version",
+          "workflowName"
+        ],
+        "type": "object",
+        "properties": {
+          "codeInfo": {
+            "$ref": "#/components/schemas/model.CodeInfo"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deployUser": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          },
+          "envName": {
+            "type": "string"
+          },
+          "imageInfo": {
+            "$ref": "#/components/schemas/model.ImageInfo"
+          },
+          "note": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "triggerType": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.ApplicationRollbackResponse": {
+        "required": [
+          "record"
+        ],
+        "type": "object",
+        "properties": {
+          "record": {
+            "$ref": "#/components/schemas/v1.WorkflowRecordBase"
+          }
+        }
+      },
+      "v1.ApplicationStatisticsResponse": {
+        "required": [
+          "envCount",
+          "revisionCount",
+          "targetCount",
+          "workflowCount"
+        ],
+        "type": "object",
+        "properties": {
+          "envCount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "revisionCount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "targetCount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "workflowCount": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "v1.ApplicationStatusListResponse": {
+        "required": [
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ApplicationStatusResponse"
+            }
+          }
+        }
+      },
+      "v1.ApplicationStatusResponse": {
+        "required": [
+          "envName",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "envName": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/common.AppStatus"
+          }
+        }
+      },
+      "v1.ApplicationTemplateBase": {
+        "required": [
+          "createTime",
+          "templateName",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "templateName": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "versions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ApplicationTemplateVersion"
+            }
+          }
+        }
+      },
+      "v1.ApplicationTemplateVersion": {
+        "required": [
+          "createTime",
+          "createUser",
+          "description",
+          "updateTime",
+          "version"
+        ],
+        "type": "object",
+        "properties": {
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createUser": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.ApplicationTrait": {
+        "required": [
+          "createTime",
+          "properties",
+          "type",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/model.JSONStruct"
+          },
+          "type": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "v1.ApplicationTriggerBase": {
+        "required": [
+          "createTime",
+          "name",
+          "payloadType",
+          "registry",
+          "token",
+          "type",
+          "updateTime",
+          "workflowName"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "componentName": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "payloadType": {
+            "type": "string"
+          },
+          "registry": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.ChartVersionListResponse": {
+        "required": [
+          "versions"
+        ],
+        "type": "object",
+        "properties": {
+          "versions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/repo.ChartVersion"
+            }
+          }
+        }
+      },
+      "v1.CloudShellPrepareResponse": {
+        "required": [
+          "message",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.ClusterBase": {
+        "required": [
+          "apiServerURL",
+          "dashboardURL",
+          "name",
+          "providerInfo",
+          "reason",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "apiServerURL": {
+            "type": "string"
+          },
+          "dashboardURL": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "providerInfo": {
+            "$ref": "#/components/schemas/model.ProviderInfo"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.ClusterResourceInfo": {
+        "required": [
+          "cpuCapacity",
+          "cpuUsed",
+          "masterNumber",
+          "memoryCapacity",
+          "memoryUsed",
+          "podCapacity",
+          "podUsed",
+          "workerNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "cpuCapacity": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "cpuUsed": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "gpuCapacity": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "gpuUsed": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "masterNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "memoryCapacity": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "memoryUsed": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "podCapacity": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "podUsed": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "storageClassList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "workerNumber": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "v1.ClusterTarget": {
+        "required": [
+          "clusterName"
+        ],
+        "type": "object",
+        "properties": {
+          "clusterName": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CompareLatestWithRunningOption": {
+        "required": [
+          "env"
+        ],
+        "type": "object",
+        "properties": {
+          "env": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CompareRevisionWithLatestOption": {
+        "type": "object",
+        "properties": {
+          "revision": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CompareRevisionWithRunningOption": {
+        "type": "object",
+        "properties": {
+          "revision": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.ComponentBase": {
+        "required": [
+          "alias",
+          "componentType",
+          "createTime",
+          "dependsOn",
+          "description",
+          "main",
+          "name",
+          "traits",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "componentType": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.InputItem"
+            }
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "main": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.OutputItem"
+            }
+          },
+          "traits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ApplicationTrait"
+            }
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "workloadType": {
+            "$ref": "#/components/schemas/common.WorkloadTypeDescriptor"
+          }
+        }
+      },
+      "v1.ComponentListResponse": {
+        "required": [
+          "components"
+        ],
+        "type": "object",
+        "properties": {
+          "components": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ComponentBase"
+            }
+          }
+        }
+      },
+      "v1.ComponentSelector": {
+        "required": [
+          "components"
+        ],
+        "type": "object",
+        "properties": {
+          "components": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.Config": {
+        "type": "object",
+        "properties": {
+          "ArgsEscaped": {
+            "type": "boolean"
+          },
+          "AttachStderr": {
+            "type": "boolean"
+          },
+          "AttachStdin": {
+            "type": "boolean"
+          },
+          "AttachStdout": {
+            "type": "boolean"
+          },
+          "Cmd": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "Domainname": {
+            "type": "string"
+          },
+          "Entrypoint": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "Env": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ExposedPorts": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/v1.Config.ExposedPorts"
+            }
+          },
+          "Healthcheck": {
+            "$ref": "#/components/schemas/v1.HealthConfig"
+          },
+          "Hostname": {
+            "type": "string"
+          },
+          "Image": {
+            "type": "string"
+          },
+          "Labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "MacAddress": {
+            "type": "string"
+          },
+          "NetworkDisabled": {
+            "type": "boolean"
+          },
+          "OnBuild": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "OpenStdin": {
+            "type": "boolean"
+          },
+          "Shell": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "StdinOnce": {
+            "type": "boolean"
+          },
+          "StopSignal": {
+            "type": "string"
+          },
+          "Tty": {
+            "type": "boolean"
+          },
+          "User": {
+            "type": "string"
+          },
+          "Volumes": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/v1.Config.Volumes"
+            }
+          },
+          "WorkingDir": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.Config.ExposedPorts": {
+        "type": "object"
+      },
+      "v1.Config.Volumes": {
+        "type": "object"
+      },
+      "v1.ConfigFile": {
+        "required": [
+          "architecture",
+          "config",
+          "os",
+          "rootfs"
+        ],
+        "type": "object",
+        "properties": {
+          "architecture": {
+            "type": "string"
+          },
+          "author": {
+            "type": "string"
+          },
+          "config": {
+            "$ref": "#/components/schemas/v1.Config"
+          },
+          "container": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string"
+          },
+          "docker_version": {
+            "type": "string"
+          },
+          "history": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.History"
+            }
+          },
+          "os": {
+            "type": "string"
+          },
+          "os.features": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "os.version": {
+            "type": "string"
+          },
+          "rootfs": {
+            "$ref": "#/components/schemas/v1.RootFS"
+          },
+          "variant": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.ConfigTemplate": {
+        "required": [
+          "alias",
+          "createTime",
+          "description",
+          "name",
+          "namespace",
+          "scope",
+          "sensitive"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "sensitive": {
+            "type": "boolean"
+          }
+        }
+      },
+      "v1.ConfigTemplateDetail": {
+        "required": [
+          "alias",
+          "createTime",
+          "description",
+          "name",
+          "namespace",
+          "schema",
+          "scope",
+          "sensitive",
+          "uiSchema"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "sensitive": {
+            "type": "boolean"
+          },
+          "uiSchema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/schema.UIParameter"
+            }
+          }
+        }
+      },
+      "v1.ConnectCloudClusterRequest": {
+        "required": [
+          "accessKeyID",
+          "accessKeySecret",
+          "clusterID",
+          "icon",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "accessKeyID": {
+            "type": "string"
+          },
+          "accessKeySecret": {
+            "type": "string"
+          },
+          "alias": {
+            "type": "string"
+          },
+          "clusterID": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.Context": {
+        "required": [
+          "name",
+          "values"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.Value"
+            }
+          }
+        }
+      },
+      "v1.ContextNameResponse": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CreateAddonRegistryRequest": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "git": {
+            "$ref": "#/components/schemas/addon.GitAddonSource"
+          },
+          "gitee": {
+            "$ref": "#/components/schemas/addon.GiteeAddonSource"
+          },
+          "gitlab": {
+            "$ref": "#/components/schemas/addon.GitlabAddonSource"
+          },
+          "helm": {
+            "$ref": "#/components/schemas/addon.HelmSource"
+          },
+          "name": {
+            "type": "string"
+          },
+          "oss": {
+            "$ref": "#/components/schemas/addon.OSSAddonSource"
+          }
+        }
+      },
+      "v1.CreateApplicationEnvbindingRequest": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CreateApplicationRequest": {
+        "required": [
+          "component",
+          "icon",
+          "name",
+          "project"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "component": {
+            "$ref": "#/components/schemas/v1.CreateComponentRequest"
+          },
+          "description": {
+            "type": "string"
+          },
+          "envBinding": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.EnvBinding"
+            }
+          },
+          "icon": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "project": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CreateApplicationTemplateRequest": {
+        "required": [
+          "description",
+          "templateName",
+          "version"
+        ],
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "templateName": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CreateApplicationTraitRequest": {
+        "required": [
+          "properties",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CreateApplicationTriggerRequest": {
+        "required": [
+          "name",
+          "payloadType",
+          "type",
+          "workflowName"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "componentName": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "payloadType": {
+            "type": "string"
+          },
+          "registry": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CreateCloudClusterRequest": {
+        "required": [
+          "accessKeyID",
+          "accessKeySecret",
+          "cpuCoresPerWorker",
+          "memoryPerWorker",
+          "name",
+          "workerNumber",
+          "zone"
+        ],
+        "type": "object",
+        "properties": {
+          "accessKeyID": {
+            "type": "string"
+          },
+          "accessKeySecret": {
+            "type": "string"
+          },
+          "cpuCoresPerWorker": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "memoryPerWorker": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "workerNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "zone": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CreateCloudClusterResponse": {
+        "required": [
+          "clusterID",
+          "clusterName",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "clusterID": {
+            "type": "string"
+          },
+          "clusterName": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CreateClusterNamespaceRequest": {
+        "required": [
+          "namespace"
+        ],
+        "type": "object",
+        "properties": {
+          "namespace": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CreateClusterNamespaceResponse": {
+        "required": [
+          "exists"
+        ],
+        "type": "object",
+        "properties": {
+          "exists": {
+            "type": "boolean"
+          }
+        }
+      },
+      "v1.CreateClusterRequest": {
+        "required": [
+          "icon",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "dashboardURL": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "kubeConfig": {
+            "type": "string"
+          },
+          "kubeConfigSecret": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CreateComponentRequest": {
+        "required": [
+          "componentType",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "componentType": {
+            "type": "string"
+          },
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.InputItem"
+            }
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.OutputItem"
+            }
+          },
+          "properties": {
+            "type": "string"
+          },
+          "traits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.CreateApplicationTraitRequest"
+            }
+          }
+        }
+      },
+      "v1.CreateConfigDistributionRequest": {
+        "required": [
+          "configs",
+          "name",
+          "targets"
+        ],
+        "type": "object",
+        "properties": {
+          "configs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.NamespacedName"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ClusterTarget"
+            }
+          }
+        }
+      },
+      "v1.CreateConfigRequest": {
+        "required": [
+          "alias",
+          "description",
+          "name",
+          "template"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "string"
+          },
+          "template": {
+            "$ref": "#/components/schemas/v1.NamespacedName"
+          }
+        }
+      },
+      "v1.CreateContextValuesRequest": {
+        "required": [
+          "name",
+          "values"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.Value"
+            }
+          }
+        }
+      },
+      "v1.CreateEnvRequest": {
+        "required": [
+          "name",
+          "namespace",
+          "project"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "allowTargetConflict": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "project": {
+            "type": "string"
+          },
+          "targets": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.CreatePermissionRequest": {
+        "required": [
+          "actions",
+          "alias",
+          "effect",
+          "name",
+          "resources"
+        ],
+        "type": "object",
+        "properties": {
+          "actions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "alias": {
+            "type": "string"
+          },
+          "effect": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "resources": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.CreatePipelineRequest": {
+        "required": [
+          "name",
+          "spec"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "spec": {
+            "$ref": "#/components/schemas/model.WorkflowSpec"
+          }
+        }
+      },
+      "v1.CreatePolicyRequest": {
+        "required": [
+          "alias",
+          "description",
+          "envName",
+          "name",
+          "properties",
+          "type",
+          "workflowPolicyBind"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "envName": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "workflowPolicyBind": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.WorkflowPolicyBinding"
+            }
+          }
+        }
+      },
+      "v1.CreateProjectRequest": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.CreateRoleRequest": {
+        "required": [
+          "alias",
+          "name",
+          "permissions"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.CreateTargetRequest": {
+        "required": [
+          "name",
+          "project"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "cluster": {
+            "$ref": "#/components/schemas/v1.ClusterTarget"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "project": {
+            "type": "string"
+          },
+          "variable": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      },
+      "v1.CreateUserRequest": {
+        "required": [
+          "email",
+          "name",
+          "password",
+          "roles"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.CreateWorkflowRequest": {
+        "required": [
+          "default",
+          "envName",
+          "mode",
+          "name",
+          "subMode"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "default": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "envName": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.WorkflowStep"
+            }
+          },
+          "subMode": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.DefinitionBase": {
+        "required": [
+          "alias",
+          "category",
+          "description",
+          "icon",
+          "labels",
+          "name",
+          "ownerAddon",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "component": {
+            "$ref": "#/components/schemas/v1beta1.ComponentDefinitionSpec"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "ownerAddon": {
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/v1beta1.PolicyDefinitionSpec"
+          },
+          "status": {
+            "type": "string"
+          },
+          "trait": {
+            "$ref": "#/components/schemas/v1beta1.TraitDefinitionSpec"
+          },
+          "workflowStep": {
+            "$ref": "#/components/schemas/v1beta1.WorkflowStepDefinitionSpec"
+          },
+          "workloadType": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.Descriptor": {
+        "required": [
+          "digest",
+          "mediaType",
+          "size"
+        ],
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "artifactType": {
+            "type": "string"
+          },
+          "data": {
+            "type": "string"
+          },
+          "digest": {
+            "type": "string"
+          },
+          "mediaType": {
+            "type": "string"
+          },
+          "platform": {
+            "$ref": "#/components/schemas/v1.Platform"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "urls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.DetailAddonResponse": {
+        "required": [
+          "availableVersions",
+          "definitions",
+          "description",
+          "icon",
+          "invisible",
+          "name",
+          "schema",
+          "uiSchema",
+          "version"
+        ],
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "availableVersions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "definitions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.AddonDefinition"
+            }
+          },
+          "dependencies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/addon.Dependency"
+            }
+          },
+          "deployTo": {
+            "$ref": "#/components/schemas/addon.DeployTo"
+          },
+          "description": {
+            "type": "string"
+          },
+          "detail": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "invisible": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "needNamespace": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "registryName": {
+            "type": "string"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "system": {
+            "$ref": "#/components/schemas/addon.SystemRequirements"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "uiSchema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/schema.UIParameter"
+            }
+          },
+          "url": {
+            "type": "string"
+          },
+          "uxPlugins": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.DetailApplicationResponse": {
+        "required": [
+          "alias",
+          "createTime",
+          "description",
+          "envBindings",
+          "icon",
+          "name",
+          "policies",
+          "project",
+          "resourceInfo",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "envBindings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "icon": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "policies": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "project": {
+            "$ref": "#/components/schemas/v1.ProjectBase"
+          },
+          "readOnly": {
+            "type": "boolean"
+          },
+          "resourceInfo": {
+            "$ref": "#/components/schemas/v1.ApplicationResourceInfo"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "v1.DetailClusterResponse": {
+        "required": [
+          "alias",
+          "apiServerURL",
+          "createTime",
+          "dashboardURL",
+          "description",
+          "icon",
+          "kubeConfig",
+          "kubeConfigSecret",
+          "labels",
+          "name",
+          "provider",
+          "reason",
+          "resourceInfo",
+          "status",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "apiServerURL": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dashboardURL": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "kubeConfig": {
+            "type": "string"
+          },
+          "kubeConfigSecret": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/model.ProviderInfo"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "resourceInfo": {
+            "$ref": "#/components/schemas/v1.ClusterResourceInfo"
+          },
+          "status": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "v1.DetailComponentResponse": {
+        "required": [
+          "alias",
+          "appPrimaryKey",
+          "createTime",
+          "creator",
+          "definition",
+          "main",
+          "name",
+          "type",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "appPrimaryKey": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "definition": {
+            "$ref": "#/components/schemas/v1beta1.ComponentDefinitionSpec"
+          },
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "externalRevision": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.InputItem"
+            }
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "main": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.OutputItem"
+            }
+          },
+          "properties": {
+            "$ref": "#/components/schemas/model.JSONStruct"
+          },
+          "scopes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "traits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.ApplicationTrait"
+            }
+          },
+          "type": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "workloadType": {
+            "$ref": "#/components/schemas/common.WorkloadTypeDescriptor"
+          }
+        }
+      },
+      "v1.DetailDefinitionResponse": {
+        "required": [
+          "alias",
+          "category",
+          "description",
+          "icon",
+          "labels",
+          "name",
+          "ownerAddon",
+          "schema",
+          "status",
+          "uiSchema"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "component": {
+            "$ref": "#/components/schemas/v1beta1.ComponentDefinitionSpec"
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "ownerAddon": {
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/v1beta1.PolicyDefinitionSpec"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "trait": {
+            "$ref": "#/components/schemas/v1beta1.TraitDefinitionSpec"
+          },
+          "uiSchema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/schema.UIParameter"
+            }
+          },
+          "workflowStep": {
+            "$ref": "#/components/schemas/v1beta1.WorkflowStepDefinitionSpec"
+          },
+          "workloadType": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.DetailPolicyResponse": {
+        "required": [
+          "alias",
+          "createTime",
+          "creator",
+          "description",
+          "envName",
+          "name",
+          "properties",
+          "type",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "envName": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/model.JSONStruct"
+          },
+          "type": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "workflowPolicyBind": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.WorkflowPolicyBinding"
+            }
+          }
+        }
+      },
+      "v1.DetailRevisionResponse": {
+        "required": [
+          "appPrimaryKey",
+          "createTime",
+          "deployUser",
+          "envName",
+          "note",
+          "reason",
+          "revisionCRName",
+          "status",
+          "triggerType",
+          "updateTime",
+          "version",
+          "workflowName"
+        ],
+        "type": "object",
+        "properties": {
+          "appPrimaryKey": {
+            "type": "string"
+          },
+          "applyAppConfig": {
+            "type": "string"
+          },
+          "codeInfo": {
+            "$ref": "#/components/schemas/model.CodeInfo"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deployUser": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          },
+          "envName": {
+            "type": "string"
+          },
+          "imageInfo": {
+            "$ref": "#/components/schemas/model.ImageInfo"
+          },
+          "note": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "revisionCRName": {
+            "type": "string"
+          },
+          "rollbackVersion": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "triggerType": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "version": {
+            "type": "string"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.DetailTargetResponse": {
+        "required": [
+          "createTime",
+          "name",
+          "project",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "appNum": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "cluster": {
+            "$ref": "#/components/schemas/v1.ClusterTarget"
+          },
+          "clusterAlias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "variable": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      },
+      "v1.DetailUserResponse": {
+        "required": [
+          "createTime",
+          "disabled",
+          "email",
+          "lastLoginTime",
+          "name",
+          "projects",
+          "roles"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "disabled": {
+            "type": "boolean"
+          },
+          "email": {
+            "type": "string"
+          },
+          "lastLoginTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "projects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.UserProjectBase"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.NameAlias"
+            }
+          }
+        }
+      },
+      "v1.DetailWorkflowRecordResponse": {
+        "required": [
+          "applicationRevision",
+          "deployTime",
+          "deployUser",
+          "message",
+          "mode",
+          "name",
+          "namespace",
+          "note",
+          "status",
+          "triggerType",
+          "workflowAlias",
+          "workflowName"
+        ],
+        "type": "object",
+        "properties": {
+          "applicationRevision": {
+            "type": "string"
+          },
+          "deployTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deployUser": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "message": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.WorkflowStepStatus"
+            }
+          },
+          "triggerType": {
+            "type": "string"
+          },
+          "workflowAlias": {
+            "type": "string"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.DetailWorkflowResponse": {
+        "required": [
+          "alias",
+          "createTime",
+          "default",
+          "description",
+          "enable",
+          "envName",
+          "mode",
+          "name",
+          "subMode",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "default": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "enable": {
+            "type": "boolean"
+          },
+          "envName": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.WorkflowStep"
+            }
+          },
+          "subMode": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "v1.DexConfigResponse": {
+        "required": [
+          "clientID",
+          "clientSecret",
+          "issuer",
+          "redirectURL"
+        ],
+        "type": "object",
+        "properties": {
+          "clientID": {
+            "type": "string"
+          },
+          "clientSecret": {
+            "type": "string"
+          },
+          "issuer": {
+            "type": "string"
+          },
+          "redirectURL": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.EmptyResponse": {
+        "type": "object"
+      },
+      "v1.EnableAddonRequest": {
+        "type": "object",
+        "properties": {
+          "args": {
+            "type": "object",
+            "properties": {}
+          },
+          "clusters": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "registryName": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.EnablingProgress": {
+        "required": [
+          "enabled_components",
+          "total_components"
+        ],
+        "type": "object",
+        "properties": {
+          "enabled_components": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "total_components": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "v1.Env": {
+        "required": [
+          "alias",
+          "createTime",
+          "name",
+          "namespace",
+          "project",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          },
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.NameAlias"
+            }
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "v1.EnvBinding": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.EnvBindingBase": {
+        "required": [
+          "appDeployName",
+          "appDeployNamespace",
+          "createTime",
+          "name",
+          "targetNames",
+          "updateTime",
+          "workflow"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "appDeployName": {
+            "type": "string"
+          },
+          "appDeployNamespace": {
+            "type": "string"
+          },
+          "componentSelector": {
+            "$ref": "#/components/schemas/v1.ComponentSelector"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "targetNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.EnvBindingTarget"
+            }
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          }
+        }
+      },
+      "v1.EnvBindingTarget": {
+        "required": [
+          "alias",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "cluster": {
+            "$ref": "#/components/schemas/v1.ClusterTarget"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.GetLoginTypeResponse": {
+        "required": [
+          "loginType"
+        ],
+        "type": "object",
+        "properties": {
+          "loginType": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.GetPipelineResponse": {
+        "required": [
+          "alias",
+          "createTime",
+          "description",
+          "info",
+          "name",
+          "project",
+          "spec"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "info": {
+            "$ref": "#/components/schemas/v1.PipelineInfo"
+          },
+          "name": {
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          },
+          "spec": {
+            "$ref": "#/components/schemas/model.WorkflowSpec"
+          }
+        }
+      },
+      "v1.GetPipelineRunInputResponse": {
+        "required": [
+          "inputs"
+        ],
+        "type": "object",
+        "properties": {
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.StepInputBase"
+            }
+          }
+        }
+      },
+      "v1.GetPipelineRunLogResponse": {
+        "required": [
+          "id",
+          "log",
+          "name",
+          "phase",
+          "source",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "log": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phase": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.GetPipelineRunOutputResponse": {
+        "required": [
+          "outputs"
+        ],
+        "type": "object",
+        "properties": {
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.StepOutputBase"
+            }
+          }
+        }
+      },
+      "v1.HandleApplicationTriggerWebhookRequest": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string"
+          },
+          "codeInfo": {
+            "$ref": "#/components/schemas/model.CodeInfo"
+          },
+          "step": {
+            "type": "string"
+          },
+          "upgrade": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/model.JSONStruct"
+            }
+          }
+        }
+      },
+      "v1.Hash": {
+        "required": [
+          "Algorithm",
+          "Hex"
+        ],
+        "type": "object",
+        "properties": {
+          "Algorithm": {
+            "type": "string"
+          },
+          "Hex": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.HealthConfig": {
+        "type": "object",
+        "properties": {
+          "Interval": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Retries": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "StartPeriod": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "Test": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "Timeout": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "v1.History": {
+        "type": "object",
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "empty_layer": {
+            "type": "boolean"
+          }
+        }
+      },
+      "v1.ImageInfo": {
+        "required": [
+          "manifest",
+          "name",
+          "registry",
+          "secretNames",
+          "size"
+        ],
+        "type": "object",
+        "properties": {
+          "info": {
+            "$ref": "#/components/schemas/v1.ConfigFile"
+          },
+          "manifest": {
+            "$ref": "#/components/schemas/v1.Manifest"
+          },
+          "message": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "registry": {
+            "type": "string"
+          },
+          "secretNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "v1.ImageRegistry": {
+        "required": [
+          "domain",
+          "name",
+          "secretName"
+        ],
+        "type": "object",
+        "properties": {
+          "domain": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "secretName": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.InitAdminRequest": {
+        "required": [
+          "email",
+          "name",
+          "password"
+        ],
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.InitAdminResponse": {
+        "required": [
+          "success"
+        ],
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          }
+        }
+      },
+      "v1.InputVar": {
+        "required": [
+          "from",
+          "fromStep",
+          "parameterKey",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "fromStep": {
+            "type": "string"
+          },
+          "parameterKey": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.InstallPluginRequest": {
+        "required": [
+          "url"
+        ],
+        "type": "object",
+        "properties": {
+          "disable": {
+            "type": "boolean"
+          },
+          "options": {
+            "$ref": "#/components/schemas/common.HTTPOption"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.ListAddonRegistryResponse": {
+        "required": [
+          "registries"
+        ],
+        "type": "object",
+        "properties": {
+          "registries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.AddonRegistry"
+            }
+          }
+        }
+      },
+      "v1.ListAddonResponse": {
+        "required": [
+          "addons"
+        ],
+        "type": "object",
+        "properties": {
+          "addons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.AddonInfo"
+            }
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.ListApplicationEnvBinding": {
+        "required": [
+          "envBindings"
+        ],
+        "type": "object",
+        "properties": {
+          "envBindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.EnvBindingBase"
+            }
+          }
+        }
+      },
+      "v1.ListApplicationPolicy": {
+        "required": [
+          "policies"
+        ],
+        "type": "object",
+        "properties": {
+          "policies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.PolicyBase"
+            }
+          }
+        }
+      },
+      "v1.ListApplicationResponse": {
+        "required": [
+          "applications"
+        ],
+        "type": "object",
+        "properties": {
+          "applications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ApplicationBase"
+            }
+          }
+        }
+      },
+      "v1.ListApplicationTriggerResponse": {
+        "required": [
+          "triggers"
+        ],
+        "type": "object",
+        "properties": {
+          "triggers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ApplicationTriggerBase"
+            }
+          }
+        }
+      },
+      "v1.ListCloudClusterCreationResponse": {
+        "required": [
+          "creations"
+        ],
+        "type": "object",
+        "properties": {
+          "creations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.CreateCloudClusterResponse"
+            }
+          }
+        }
+      },
+      "v1.ListCloudClusterResponse": {
+        "required": [
+          "clusters",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "clusters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/cloudprovider.CloudCluster"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "v1.ListClusterResponse": {
+        "required": [
+          "clusters",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "clusters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ClusterBase"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "v1.ListConfigDistributionResponse": {
+        "required": [
+          "distributions"
+        ],
+        "type": "object",
+        "properties": {
+          "distributions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/config.Distribution"
+            }
+          }
+        }
+      },
+      "v1.ListConfigResponse": {
+        "required": [
+          "configs"
+        ],
+        "type": "object",
+        "properties": {
+          "configs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.Config"
+            }
+          }
+        }
+      },
+      "v1.ListConfigTemplateResponse": {
+        "required": [
+          "templates"
+        ],
+        "type": "object",
+        "properties": {
+          "templates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ConfigTemplate"
+            }
+          }
+        }
+      },
+      "v1.ListContextValueResponse": {
+        "required": [
+          "contexts",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "contexts": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/model.Value"
+              }
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "v1.ListDefinitionResponse": {
+        "required": [
+          "definitions"
+        ],
+        "type": "object",
+        "properties": {
+          "definitions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.DefinitionBase"
+            }
+          }
+        }
+      },
+      "v1.ListEnabledAddonResponse": {
+        "required": [
+          "enabledAddons"
+        ],
+        "type": "object",
+        "properties": {
+          "enabledAddons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.AddonBaseStatus"
+            }
+          }
+        }
+      },
+      "v1.ListEnvResponse": {
+        "required": [
+          "envs",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "envs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.Env"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "v1.ListImageRegistryResponse": {
+        "required": [
+          "registries"
+        ],
+        "type": "object",
+        "properties": {
+          "registries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ImageRegistry"
+            }
+          }
+        }
+      },
+      "v1.ListPipelineResponse": {
+        "required": [
+          "pipelines",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "pipelines": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.PipelineListItem"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "v1.ListPipelineRunResponse": {
+        "required": [
+          "runs",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "runs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.PipelineRunBriefing"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "v1.ListPluginResponse": {
+        "required": [
+          "plugins"
+        ],
+        "type": "object",
+        "properties": {
+          "plugins": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.PluginDTO"
+            }
+          }
+        }
+      },
+      "v1.ListProjectResponse": {
+        "required": [
+          "projects",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "projects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ProjectBase"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "v1.ListProjectUsersResponse": {
+        "required": [
+          "total",
+          "users"
+        ],
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ProjectUserBase"
+            }
+          }
+        }
+      },
+      "v1.ListRevisionsResponse": {
+        "required": [
+          "revisions",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "revisions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.ApplicationRevisionBase"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "v1.ListRolesResponse": {
+        "required": [
+          "roles",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "roles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.RoleBase"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "v1.ListTargetResponse": {
+        "required": [
+          "targets",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.TargetBase"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "v1.ListTerraformProviderResponse": {
+        "required": [
+          "providers"
+        ],
+        "type": "object",
+        "properties": {
+          "providers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.TerraformProvider"
+            }
+          }
+        }
+      },
+      "v1.ListUserResponse": {
+        "required": [
+          "total",
+          "users"
+        ],
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.DetailUserResponse"
+            }
+          }
+        }
+      },
+      "v1.ListWorkflowRecordsResponse": {
+        "required": [
+          "records",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.WorkflowRecord"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "v1.ListWorkflowResponse": {
+        "required": [
+          "workflows"
+        ],
+        "type": "object",
+        "properties": {
+          "workflows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.WorkflowBase"
+            }
+          }
+        }
+      },
+      "v1.LoginRequest": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string",
+            "example": "VelaUX12345"
+          },
+          "username": {
+            "type": "string",
+            "example": "admin"
+          }
+        }
+      },
+      "v1.LoginResponse": {
+        "required": [
+          "accessToken",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object",
+        "properties": {
+          "accessToken": {
+            "type": "string"
+          },
+          "refreshToken": {
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/v1.UserBase"
+          }
+        }
+      },
+      "v1.LoginUserInfoResponse": {
+        "required": [
+          "createTime",
+          "disabled",
+          "email",
+          "lastLoginTime",
+          "name",
+          "platformPermissions",
+          "projectPermissions",
+          "projects"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "disabled": {
+            "type": "boolean"
+          },
+          "email": {
+            "type": "string"
+          },
+          "lastLoginTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "platformPermissions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.PermissionBase"
+            }
+          },
+          "projectPermissions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/v1.PermissionBase"
+              }
+            }
+          },
+          "projects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.UserProjectBase"
+            }
+          }
+        }
+      },
+      "v1.ManagedPluginDTO": {
+        "required": [
+          "backend",
+          "backendService",
+          "backendType",
+          "baseURL",
+          "category",
+          "class",
+          "defaultNavURL",
+          "enabled",
+          "id",
+          "includes",
+          "info",
+          "jsonSetting",
+          "module",
+          "name",
+          "proxy",
+          "secureJsonFields",
+          "subType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "authSecret": {
+            "$ref": "#/components/schemas/types.KubernetesSecret"
+          },
+          "authType": {
+            "type": "string"
+          },
+          "backend": {
+            "type": "boolean"
+          },
+          "backendService": {
+            "$ref": "#/components/schemas/types.KubernetesService"
+          },
+          "backendType": {
+            "type": "string"
+          },
+          "baseURL": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "class": {
+            "type": "string"
+          },
+          "defaultNavURL": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "includes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/types.Includes"
+            }
+          },
+          "info": {
+            "$ref": "#/components/schemas/types.Info"
+          },
+          "jsonSetting": {
+            "type": "object",
+            "properties": {}
+          },
+          "kubePermissions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.PolicyRule"
+            }
+          },
+          "module": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "proxy": {
+            "type": "boolean"
+          },
+          "requirement": {
+            "$ref": "#/components/schemas/types.Requirement"
+          },
+          "routes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/types.Route"
+            }
+          },
+          "secureJsonFields": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "subType": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.Manifest": {
+        "required": [
+          "config",
+          "layers",
+          "schemaVersion"
+        ],
+        "type": "object",
+        "properties": {
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "config": {
+            "$ref": "#/components/schemas/v1.Descriptor"
+          },
+          "layers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.Descriptor"
+            }
+          },
+          "mediaType": {
+            "type": "string"
+          },
+          "schemaVersion": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/v1.Descriptor"
+          }
+        }
+      },
+      "v1.NameAlias": {
+        "required": [
+          "alias",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.NamespacedName": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.ObjectReference": {
+        "type": "object",
+        "properties": {
+          "apiVersion": {
+            "type": "string",
+            "description": "API version of the referent."
+          },
+          "fieldPath": {
+            "type": "string",
+            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object."
+          },
+          "kind": {
+            "type": "string",
+            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+          },
+          "namespace": {
+            "type": "string",
+            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+          },
+          "resourceVersion": {
+            "type": "string",
+            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency"
+          },
+          "uid": {
+            "type": "string",
+            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids"
+          }
+        },
+        "description": "ObjectReference contains enough information to let you inspect or modify the referred object."
+      },
+      "v1.OutputVar": {
+        "required": [
+          "name",
+          "value",
+          "valueFrom"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.PermissionBase": {
+        "required": [
+          "actions",
+          "alias",
+          "createTime",
+          "effect",
+          "name",
+          "resources",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "actions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "effect": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "resources": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "v1.PipelineBase": {
+        "required": [
+          "alias",
+          "createTime",
+          "description",
+          "name",
+          "project",
+          "spec"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          },
+          "spec": {
+            "$ref": "#/components/schemas/model.WorkflowSpec"
+          }
+        }
+      },
+      "v1.PipelineInfo": {
+        "required": [
+          "lastRun",
+          "runStat"
+        ],
+        "type": "object",
+        "properties": {
+          "lastRun": {
+            "$ref": "#/components/schemas/v1.PipelineRun"
+          },
+          "runStat": {
+            "$ref": "#/components/schemas/v1.RunStat"
+          }
+        }
+      },
+      "v1.PipelineListItem": {
+        "required": [
+          "alias",
+          "createTime",
+          "description",
+          "info",
+          "name",
+          "project"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "info": {
+            "$ref": "#/components/schemas/v1.PipelineInfo"
+          },
+          "name": {
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          }
+        }
+      },
+      "v1.PipelineMeta": {
+        "required": [
+          "alias",
+          "createTime",
+          "description",
+          "name",
+          "project"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          }
+        }
+      },
+      "v1.PipelineMetaResponse": {
+        "required": [
+          "alias",
+          "createTime",
+          "description",
+          "name",
+          "project"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          }
+        }
+      },
+      "v1.PipelineRun": {
+        "required": [
+          "contextName",
+          "contextValues",
+          "pipelineName",
+          "pipelineRunName",
+          "project",
+          "record",
+          "spec",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "contextName": {
+            "type": "string"
+          },
+          "contextValues": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.Value"
+            }
+          },
+          "pipelineName": {
+            "type": "string"
+          },
+          "pipelineRunName": {
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          },
+          "record": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "spec": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowRunSpec"
+          },
+          "status": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowRunStatus"
+          }
+        }
+      },
+      "v1.PipelineRunBase": {
+        "required": [
+          "contextName",
+          "contextValues",
+          "pipelineName",
+          "pipelineRunName",
+          "project",
+          "record",
+          "spec"
+        ],
+        "type": "object",
+        "properties": {
+          "contextName": {
+            "type": "string"
+          },
+          "contextValues": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.Value"
+            }
+          },
+          "pipelineName": {
+            "type": "string"
+          },
+          "pipelineRunName": {
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          },
+          "record": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "spec": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowRunSpec"
+          }
+        }
+      },
+      "v1.PipelineRunBriefing": {
+        "required": [
+          "contextName",
+          "contextValues",
+          "endTime",
+          "finished",
+          "message",
+          "phase",
+          "pipelineRunName",
+          "startTime"
+        ],
+        "type": "object",
+        "properties": {
+          "contextName": {
+            "type": "string"
+          },
+          "contextValues": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.Value"
+            }
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "finished": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "phase": {
+            "type": "string"
+          },
+          "pipelineRunName": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.PipelineRunMeta": {
+        "required": [
+          "pipelineName",
+          "pipelineRunName",
+          "project"
+        ],
+        "type": "object",
+        "properties": {
+          "pipelineName": {
+            "type": "string"
+          },
+          "pipelineRunName": {
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          }
+        }
+      },
+      "v1.Platform": {
+        "required": [
+          "architecture",
+          "os"
+        ],
+        "type": "object",
+        "properties": {
+          "architecture": {
+            "type": "string"
+          },
+          "features": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "os": {
+            "type": "string"
+          },
+          "os.features": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "os.version": {
+            "type": "string"
+          },
+          "variant": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.PluginDTO": {
+        "required": [
+          "baseURL",
+          "category",
+          "defaultNavURL",
+          "id",
+          "includes",
+          "info",
+          "module",
+          "name",
+          "subType",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "baseURL": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "defaultNavURL": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "includes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/types.Includes"
+            }
+          },
+          "info": {
+            "$ref": "#/components/schemas/types.Info"
+          },
+          "module": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "subType": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.PluginEnableRequest": {
+        "required": [
+          "jsonData",
+          "secureJsonData"
+        ],
+        "type": "object",
+        "properties": {
+          "jsonData": {
+            "type": "object",
+            "properties": {}
+          },
+          "secureJsonData": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      },
+      "v1.PolicyBase": {
+        "required": [
+          "alias",
+          "createTime",
+          "creator",
+          "description",
+          "envName",
+          "name",
+          "properties",
+          "type",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "envName": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/model.JSONStruct"
+          },
+          "type": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "v1.PolicyRule": {
+        "required": [
+          "verbs"
+        ],
+        "type": "object",
+        "properties": {
+          "apiGroups": {
+            "type": "array",
+            "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "nonResourceURLs": {
+            "type": "array",
+            "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "resourceNames": {
+            "type": "array",
+            "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "resources": {
+            "type": "array",
+            "description": "Resources is a list of resources this rule applies to. '*' represents all resources.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "verbs": {
+            "type": "array",
+            "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to."
+      },
+      "v1.ProjectBase": {
+        "required": [
+          "alias",
+          "createTime",
+          "description",
+          "name",
+          "namespace",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "v1.ProjectUserBase": {
+        "required": [
+          "alias",
+          "createTime",
+          "name",
+          "updateTime",
+          "userRoles"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "userRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.Properties": {
+        "type": "object"
+      },
+      "v1.PutApplicationEnvBindingRequest": {
+        "type": "object"
+      },
+      "v1.RefreshTokenResponse": {
+        "required": [
+          "accessToken",
+          "refreshToken"
+        ],
+        "type": "object",
+        "properties": {
+          "accessToken": {
+            "type": "string"
+          },
+          "refreshToken": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.RoleBase": {
+        "required": [
+          "createTime",
+          "name",
+          "permissions",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.NameAlias"
+            }
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "v1.RootFS": {
+        "required": [
+          "diff_ids",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "diff_ids": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.Hash"
+            }
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.RunPipelineRequest": {
+        "required": [
+          "contextName"
+        ],
+        "type": "object",
+        "properties": {
+          "contextName": {
+            "type": "string"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowExecuteMode"
+          }
+        }
+      },
+      "v1.RunStat": {
+        "required": [
+          "activeNum",
+          "total",
+          "week"
+        ],
+        "type": "object",
+        "properties": {
+          "activeNum": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "total": {
+            "$ref": "#/components/schemas/v1.RunStatInfo"
+          },
+          "week": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.RunStatInfo"
+            }
+          }
+        }
+      },
+      "v1.RunStatInfo": {
+        "required": [
+          "fail",
+          "success",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "fail": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "success": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "v1.SecretReference": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "name is unique within a namespace to reference a secret resource."
+          },
+          "namespace": {
+            "type": "string",
+            "description": "namespace defines the space within which the secret name must be unique."
+          }
+        },
+        "description": "SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace"
+      },
+      "v1.SimpleResponse": {
+        "required": [
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.StatisticInfo": {
+        "type": "object",
+        "properties": {
+          "appCount": {
+            "type": "string"
+          },
+          "clusterCount": {
+            "type": "string"
+          },
+          "componentDefinitionTopList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "enableAddonList": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "policyDefinitionTopList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "traitDefinitionTopList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "workflowDefinitionTopList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.StepBase": {
+        "required": [
+          "id",
+          "name",
+          "phase",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phase": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.StepInputBase": {
+        "required": [
+          "id",
+          "name",
+          "phase",
+          "type",
+          "values"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phase": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.InputVar"
+            }
+          }
+        }
+      },
+      "v1.StepOutputBase": {
+        "required": [
+          "id",
+          "name",
+          "phase",
+          "type",
+          "values"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phase": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.OutputVar"
+            }
+          }
+        }
+      },
+      "v1.SystemInfo": {
+        "required": [
+          "enableCollection",
+          "loginType",
+          "platformID"
+        ],
+        "type": "object",
+        "properties": {
+          "dexUserDefaultPlatformRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "dexUserDefaultProjects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.ProjectRef"
+            }
+          },
+          "enableCollection": {
+            "type": "boolean"
+          },
+          "installTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "loginType": {
+            "type": "string"
+          },
+          "platformID": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.SystemInfoRequest": {
+        "required": [
+          "enableCollection",
+          "loginType"
+        ],
+        "type": "object",
+        "properties": {
+          "dexUserDefaultProjects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.ProjectRef"
+            }
+          },
+          "enableCollection": {
+            "type": "boolean"
+          },
+          "loginType": {
+            "type": "string"
+          },
+          "velaAddress": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.SystemInfoResponse": {
+        "required": [
+          "enableCollection",
+          "loginType",
+          "platformID",
+          "systemVersion"
+        ],
+        "type": "object",
+        "properties": {
+          "dexUserDefaultPlatformRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "dexUserDefaultProjects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.ProjectRef"
+            }
+          },
+          "enableCollection": {
+            "type": "boolean"
+          },
+          "installTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "loginType": {
+            "type": "string"
+          },
+          "platformID": {
+            "type": "string"
+          },
+          "statisticInfo": {
+            "$ref": "#/components/schemas/v1.StatisticInfo"
+          },
+          "systemVersion": {
+            "$ref": "#/components/schemas/v1.SystemVersion"
+          }
+        }
+      },
+      "v1.SystemVersion": {
+        "required": [
+          "gitVersion",
+          "velaVersion"
+        ],
+        "type": "object",
+        "properties": {
+          "gitVersion": {
+            "type": "string"
+          },
+          "velaVersion": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.TargetBase": {
+        "required": [
+          "createTime",
+          "name",
+          "project",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "appNum": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "cluster": {
+            "$ref": "#/components/schemas/v1.ClusterTarget"
+          },
+          "clusterAlias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "project": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "variable": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      },
+      "v1.TerraformProvider": {
+        "required": [
+          "createTime",
+          "name",
+          "provider",
+          "region"
+        ],
+        "type": "object",
+        "properties": {
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.UpdateAddonRegistryRequest": {
+        "type": "object",
+        "properties": {
+          "git": {
+            "$ref": "#/components/schemas/addon.GitAddonSource"
+          },
+          "gitee": {
+            "$ref": "#/components/schemas/addon.GiteeAddonSource"
+          },
+          "gitlab": {
+            "$ref": "#/components/schemas/addon.GitlabAddonSource"
+          },
+          "helm": {
+            "$ref": "#/components/schemas/addon.HelmSource"
+          },
+          "oss": {
+            "$ref": "#/components/schemas/addon.OSSAddonSource"
+          }
+        }
+      },
+      "v1.UpdateApplicationComponentRequest": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "labels": {
+            "$ref": "#/components/schemas/v1.UpdateApplicationComponentRequest.labels"
+          },
+          "properties": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.UpdateApplicationComponentRequest.labels": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "v1.UpdateApplicationRequest": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "annotations": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.UpdateApplicationTraitRequest": {
+        "required": [
+          "properties"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.UpdateConfigRequest": {
+        "required": [
+          "alias",
+          "description"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.UpdateContextValuesRequest": {
+        "required": [
+          "values"
+        ],
+        "type": "object",
+        "properties": {
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.Value"
+            }
+          }
+        }
+      },
+      "v1.UpdateDefinitionStatusRequest": {
+        "required": [
+          "hiddenInUI",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "hiddenInUI": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.UpdatePipelineRequest": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "spec": {
+            "$ref": "#/components/schemas/model.WorkflowSpec"
+          }
+        }
+      },
+      "v1.UpdatePolicyRequest": {
+        "required": [
+          "alias",
+          "description",
+          "envName",
+          "properties",
+          "type",
+          "workflowPolicyBind"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "envName": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "workflowPolicyBind": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.WorkflowPolicyBinding"
+            }
+          }
+        }
+      },
+      "v1.UpdateProjectRequest": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.UpdateProjectUserRequest": {
+        "required": [
+          "userRoles"
+        ],
+        "type": "object",
+        "properties": {
+          "userRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.UpdateRoleRequest": {
+        "required": [
+          "alias",
+          "permissions"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.UpdateTargetRequest": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "variable": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      },
+      "v1.UpdateUISchemaRequest": {
+        "required": [
+          "type",
+          "uiSchema"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "uiSchema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/schema.UIParameter"
+            }
+          }
+        }
+      },
+      "v1.UpdateUserRequest": {
+        "required": [
+          "roles"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.UpdateWorkflowRequest": {
+        "required": [
+          "default",
+          "mode",
+          "subMode"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "default": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.WorkflowStep"
+            }
+          },
+          "subMode": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.UserBase": {
+        "required": [
+          "createTime",
+          "disabled",
+          "email",
+          "lastLoginTime",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "disabled": {
+            "type": "boolean"
+          },
+          "email": {
+            "type": "string"
+          },
+          "lastLoginTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.UserProjectBase": {
+        "required": [
+          "alias",
+          "description",
+          "joinTime",
+          "name",
+          "roles"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "joinTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/v1.NameAlias"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.NameAlias"
+            }
+          }
+        }
+      },
+      "v1.VelaQLViewResponse": {
+        "type": "object"
+      },
+      "v1.WorkflowBase": {
+        "required": [
+          "alias",
+          "createTime",
+          "default",
+          "description",
+          "enable",
+          "envName",
+          "mode",
+          "name",
+          "subMode",
+          "updateTime"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "createTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "default": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "enable": {
+            "type": "boolean"
+          },
+          "envName": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.WorkflowStep"
+            }
+          },
+          "subMode": {
+            "type": "string"
+          },
+          "updateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "v1.WorkflowPolicyBinding": {
+        "required": [
+          "name",
+          "steps"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "v1.WorkflowRecord": {
+        "required": [
+          "applicationRevision",
+          "message",
+          "mode",
+          "name",
+          "namespace",
+          "status",
+          "workflowAlias",
+          "workflowName"
+        ],
+        "type": "object",
+        "properties": {
+          "applicationRevision": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "message": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/model.WorkflowStepStatus"
+            }
+          },
+          "workflowAlias": {
+            "type": "string"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.WorkflowRecordBase": {
+        "required": [
+          "applicationRevision",
+          "message",
+          "mode",
+          "name",
+          "namespace",
+          "status",
+          "workflowAlias",
+          "workflowName"
+        ],
+        "type": "object",
+        "properties": {
+          "applicationRevision": {
+            "type": "string"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "message": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string"
+          },
+          "workflowAlias": {
+            "type": "string"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.WorkflowStep": {
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "if": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.InputItem"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowStepMeta"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.OutputItem"
+            }
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          },
+          "subSteps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1.WorkflowStepBase"
+            }
+          },
+          "timeout": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1.WorkflowStepBase": {
+        "required": [
+          "name",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          },
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "if": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.InputItem"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowStepMeta"
+          },
+          "name": {
+            "type": "string"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.OutputItem"
+            }
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          },
+          "timeout": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1alpha1.InputItem": {
+        "required": [
+          "from"
+        ],
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "parameterKey": {
+            "type": "string"
+          }
+        }
+      },
+      "v1alpha1.OutputItem": {
+        "required": [
+          "name",
+          "valueFrom"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "string"
+          }
+        }
+      },
+      "v1alpha1.StepStatus": {
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "firstExecuteTime": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastExecuteTime": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phase": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1alpha1.WorkflowExecuteMode": {
+        "type": "object",
+        "properties": {
+          "steps": {
+            "type": "string"
+          },
+          "subSteps": {
+            "type": "string"
+          }
+        }
+      },
+      "v1alpha1.WorkflowRunSpec": {
+        "type": "object",
+        "properties": {
+          "context": {
+            "type": "string"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowExecuteMode"
+          },
+          "workflowRef": {
+            "type": "string"
+          },
+          "workflowSpec": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowSpec"
+          }
+        }
+      },
+      "v1alpha1.WorkflowRunStatus": {
+        "required": [
+          "finished",
+          "mode",
+          "status",
+          "suspend",
+          "terminated"
+        ],
+        "type": "object",
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/condition.Condition"
+            }
+          },
+          "contextBackend": {
+            "$ref": "#/components/schemas/v1.ObjectReference"
+          },
+          "endTime": {
+            "type": "string"
+          },
+          "finished": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowExecuteMode"
+          },
+          "startTime": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.WorkflowStepStatus"
+            }
+          },
+          "suspend": {
+            "type": "boolean"
+          },
+          "suspendState": {
+            "type": "string"
+          },
+          "terminated": {
+            "type": "boolean"
+          }
+        }
+      },
+      "v1alpha1.WorkflowSpec": {
+        "type": "object",
+        "properties": {
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.WorkflowStep"
+            }
+          }
+        }
+      },
+      "v1alpha1.WorkflowStep": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "if": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.InputItem"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowStepMeta"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.OutputItem"
+            }
+          },
+          "properties": {
+            "type": "string"
+          },
+          "subSteps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.WorkflowStepBase"
+            }
+          },
+          "timeout": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1alpha1.WorkflowStepBase": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "dependsOn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "if": {
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.InputItem"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowStepMeta"
+          },
+          "name": {
+            "type": "string"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.OutputItem"
+            }
+          },
+          "properties": {
+            "type": "string"
+          },
+          "timeout": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1alpha1.WorkflowStepMeta": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string"
+          }
+        }
+      },
+      "v1alpha1.WorkflowStepStatus": {
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "firstExecuteTime": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lastExecuteTime": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phase": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "subSteps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.StepStatus"
+            }
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1beta1.AppPolicy": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "v1beta1.ApplicationSpec": {
+        "required": [
+          "components"
+        ],
+        "type": "object",
+        "properties": {
+          "components": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/common.ApplicationComponent"
+            }
+          },
+          "policies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1beta1.AppPolicy"
+            }
+          },
+          "workflow": {
+            "$ref": "#/components/schemas/v1beta1.Workflow"
+          }
+        }
+      },
+      "v1beta1.ComponentDefinitionSpec": {
+        "required": [
+          "workload"
+        ],
+        "type": "object",
+        "properties": {
+          "childResourceKinds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/common.ChildResourceKind"
+            }
+          },
+          "extension": {
+            "type": "string"
+          },
+          "podSpecPath": {
+            "type": "string"
+          },
+          "revisionLabel": {
+            "type": "string"
+          },
+          "schematic": {
+            "$ref": "#/components/schemas/common.Schematic"
+          },
+          "status": {
+            "$ref": "#/components/schemas/common.Status"
+          },
+          "workload": {
+            "$ref": "#/components/schemas/common.WorkloadTypeDescriptor"
+          }
+        }
+      },
+      "v1beta1.PolicyDefinitionSpec": {
+        "type": "object",
+        "properties": {
+          "definitionRef": {
+            "$ref": "#/components/schemas/common.DefinitionReference"
+          },
+          "manageHealthCheck": {
+            "type": "boolean"
+          },
+          "schematic": {
+            "$ref": "#/components/schemas/common.Schematic"
+          }
+        }
+      },
+      "v1beta1.TraitDefinitionSpec": {
+        "type": "object",
+        "properties": {
+          "appliesToWorkloads": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "conflictsWith": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "controlPlaneOnly": {
+            "type": "boolean"
+          },
+          "definitionRef": {
+            "$ref": "#/components/schemas/common.DefinitionReference"
+          },
+          "extension": {
+            "type": "string"
+          },
+          "manageWorkload": {
+            "type": "boolean"
+          },
+          "podDisruptive": {
+            "type": "boolean"
+          },
+          "revisionEnabled": {
+            "type": "boolean"
+          },
+          "schematic": {
+            "$ref": "#/components/schemas/common.Schematic"
+          },
+          "stage": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/common.Status"
+          },
+          "workloadRefPath": {
+            "type": "string"
+          }
+        }
+      },
+      "v1beta1.Workflow": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/v1alpha1.WorkflowExecuteMode"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/v1alpha1.WorkflowStep"
+            }
+          }
+        }
+      },
+      "v1beta1.WorkflowStepDefinitionSpec": {
+        "type": "object",
+        "properties": {
+          "definitionRef": {
+            "$ref": "#/components/schemas/common.DefinitionReference"
+          },
+          "schematic": {
+            "$ref": "#/components/schemas/common.Schematic"
+          }
+        }
+      }
+    }
+  },
+  "x-original-swagger-version": "2.0"
+}

--- a/docs/apidoc/swagger.json
+++ b/docs/apidoc/swagger.json
@@ -1,4 +1,7 @@
 {
+	"schemes": [
+		"http"
+	],
 	"swagger": "2.0",
 	"info": {
 		"description": "Kubevela api doc",
@@ -14,6 +17,7 @@
 		},
 		"version": "v1beta1"
 	},
+	"host": "localhost:8000",
 	"paths": {
 		"/api/v1/addon_registries": {
 			"get": {
@@ -1412,6 +1416,62 @@
 				}
 			}
 		},
+		"/api/v1/applications/{appName}/envs/{envName}/records": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"application"
+				],
+				"summary": "query application workflow execution record of one environment",
+				"operationId": "listWorkflowRecordsFromEnv",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the application.",
+						"name": "appName",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "string",
+						"description": "identifier of the environment.",
+						"name": "envName",
+						"in": "path",
+						"required": true
+					},
+					{
+						"type": "integer",
+						"description": "query the page number",
+						"name": "page",
+						"in": "query"
+					},
+					{
+						"type": "integer",
+						"description": "query the page size number",
+						"name": "pageSize",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.ListWorkflowRecordsResponse"
+						}
+					},
+					"500": {
+						"description": "Bummer, something went wrong"
+					}
+				}
+			}
+		},
 		"/api/v1/applications/{appName}/envs/{envName}/recycle": {
 			"post": {
 				"consumes": [
@@ -2018,6 +2078,46 @@
 				}
 			}
 		},
+		"/api/v1/applications/{appName}/status": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"application"
+				],
+				"summary": "get application status from all envs",
+				"operationId": "getApplicationStatusFromAllEnvs",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the application ",
+						"name": "appName",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.ApplicationStatusListResponse"
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					}
+				}
+			}
+		},
 		"/api/v1/applications/{appName}/template": {
 			"post": {
 				"consumes": [
@@ -2272,7 +2372,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.ListWorkflowResponse"
 						}
 					},
 					"500": {
@@ -2313,9 +2413,9 @@
 				],
 				"responses": {
 					"200": {
-						"description": "OK",
+						"description": "create success",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.DetailWorkflowResponse"
 						}
 					},
 					"400": {
@@ -2355,7 +2455,7 @@
 					},
 					{
 						"type": "string",
-						"description": "identifier of the workfloc.",
+						"description": "identifier of the workflow.",
 						"name": "workflowName",
 						"in": "path",
 						"required": true
@@ -2363,9 +2463,9 @@
 				],
 				"responses": {
 					"200": {
-						"description": "OK",
+						"description": "create success",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.DetailWorkflowResponse"
 						}
 					},
 					"500": {
@@ -2415,7 +2515,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.DetailWorkflowResponse"
 						}
 					},
 					"500": {
@@ -2435,7 +2535,7 @@
 				"tags": [
 					"application"
 				],
-				"summary": "deletet workflow",
+				"summary": "delete workflow",
 				"operationId": "deleteWorkflow",
 				"parameters": [
 					{
@@ -2513,7 +2613,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.ListWorkflowRecordsResponse"
 						}
 					},
 					"500": {
@@ -2564,7 +2664,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.DetailWorkflowRecordResponse"
 						}
 					},
 					"500": {
@@ -2927,6 +3027,37 @@
 				}
 			}
 		},
+		"/api/v1/auth/admin_configured": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"authentication"
+				],
+				"summary": "check admin is configured",
+				"operationId": "adminConfigured",
+				"responses": {
+					"200": {
+						"description": "",
+						"schema": {
+							"$ref": "#/definitions/v1.AdminConfiguredResponse"
+						}
+					},
+					"400": {
+						"description": "",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					}
+				}
+			}
+		},
 		"/api/v1/auth/dex_config": {
 			"get": {
 				"consumes": [
@@ -2947,6 +3078,47 @@
 						"description": "",
 						"schema": {
 							"$ref": "#/definitions/v1.DexConfigResponse"
+						}
+					},
+					"400": {
+						"description": "",
+						"schema": {
+							"$ref": "#/definitions/bcode.Bcode"
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/auth/init_admin": {
+			"put": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"authentication"
+				],
+				"summary": "initialize admin",
+				"operationId": "configureAdmin",
+				"parameters": [
+					{
+						"name": "body",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/v1.InitAdminRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "",
+						"schema": {
+							"$ref": "#/definitions/v1.InitAdminResponse"
 						}
 					},
 					"400": {
@@ -3111,7 +3283,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.CloudShellPrepareResponse"
 						}
 					},
 					"400": {
@@ -3199,7 +3371,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.ListClusterResponse"
 						}
 					},
 					"400": {
@@ -4063,7 +4235,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.ListDefinitionResponse"
 						}
 					},
 					"500": {
@@ -4104,9 +4276,9 @@
 				],
 				"responses": {
 					"200": {
-						"description": "OK",
+						"description": "create successfully",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.DetailDefinitionResponse"
 						}
 					},
 					"500": {
@@ -4149,9 +4321,12 @@
 				],
 				"responses": {
 					"200": {
-						"description": "OK",
+						"description": "update successfully",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/*schema.UIParameter"
+							}
 						}
 					},
 					"500": {
@@ -4194,9 +4369,12 @@
 				],
 				"responses": {
 					"200": {
-						"description": "OK",
+						"description": "update successfully",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/*schema.UIParameter"
+							}
 						}
 					},
 					"500": {
@@ -4388,6 +4566,272 @@
 				}
 			}
 		},
+		"/api/v1/manage/plugins": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"Plugin"
+				],
+				"summary": "List the installed plugins",
+				"operationId": "listInstalledPlugins",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.ListPluginResponse"
+						}
+					},
+					"500": {
+						"description": "Bummer, something went wrong"
+					}
+				}
+			}
+		},
+		"/api/v1/manage/plugins/{pluginId}": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"Plugin"
+				],
+				"summary": "Detail an installed plugin",
+				"operationId": "detailPlugin",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the plugin.",
+						"name": "pluginId",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.ManagedPluginDTO"
+						}
+					},
+					"500": {
+						"description": "Bummer, something went wrong"
+					}
+				}
+			}
+		},
+		"/api/v1/manage/plugins/{pluginId}/disable": {
+			"post": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"Plugin"
+				],
+				"summary": "Disable an installed plugin",
+				"operationId": "disablePlugin",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the plugin.",
+						"name": "pluginId",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.ManagedPluginDTO"
+						}
+					},
+					"500": {
+						"description": "Bummer, something went wrong"
+					}
+				}
+			}
+		},
+		"/api/v1/manage/plugins/{pluginId}/enable": {
+			"post": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"Plugin"
+				],
+				"summary": "Enable an installed plugin",
+				"operationId": "enablePlugin",
+				"parameters": [
+					{
+						"name": "body",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/v1.PluginEnableRequest"
+						}
+					},
+					{
+						"type": "string",
+						"description": "identifier of the plugin.",
+						"name": "pluginId",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.ManagedPluginDTO"
+						}
+					},
+					"500": {
+						"description": "Bummer, something went wrong"
+					}
+				}
+			}
+		},
+		"/api/v1/manage/plugins/{pluginId}/install": {
+			"post": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"Plugin"
+				],
+				"summary": "Install one specific plugin",
+				"operationId": "installPlugin",
+				"parameters": [
+					{
+						"name": "body",
+						"in": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/v1.InstallPluginRequest"
+						}
+					},
+					{
+						"type": "string",
+						"description": "identifier of the plugin.",
+						"name": "pluginId",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.ManagedPluginDTO"
+						}
+					},
+					"500": {
+						"description": "Bummer, something went wrong"
+					}
+				}
+			}
+		},
+		"/api/v1/manage/plugins/{pluginId}/setting": {
+			"post": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"Plugin"
+				],
+				"summary": "Set an installed plugin",
+				"operationId": "pluginSetting",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the plugin.",
+						"name": "pluginId",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.ManagedPluginDTO"
+						}
+					},
+					"500": {
+						"description": "Bummer, something went wrong"
+					}
+				}
+			}
+		},
+		"/api/v1/manage/plugins/{pluginId}/uninstall": {
+			"post": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"Plugin"
+				],
+				"summary": "Uninstall one specific plugin",
+				"operationId": "uninstallPlugin",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the plugin.",
+						"name": "pluginId",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.EmptyResponse"
+						}
+					},
+					"500": {
+						"description": "Bummer, something went wrong"
+					}
+				}
+			}
+		},
 		"/api/v1/payload_types": {
 			"get": {
 				"consumes": [
@@ -4559,6 +5003,71 @@
 						"schema": {
 							"$ref": "#/definitions/bcode.Bcode"
 						}
+					}
+				}
+			}
+		},
+		"/api/v1/plugins": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"Plugin"
+				],
+				"summary": "List the enabled plugins",
+				"operationId": "listEnabledPlugins",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.ListPluginResponse"
+						}
+					},
+					"500": {
+						"description": "Bummer, something went wrong"
+					}
+				}
+			}
+		},
+		"/api/v1/plugins/{pluginId}": {
+			"get": {
+				"consumes": [
+					"application/xml",
+					"application/json"
+				],
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"tags": [
+					"Plugin"
+				],
+				"summary": "Detail an installed plugin",
+				"operationId": "detailPlugin",
+				"parameters": [
+					{
+						"type": "string",
+						"description": "identifier of the plugin.",
+						"name": "pluginId",
+						"in": "path",
+						"required": true
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"schema": {
+							"$ref": "#/definitions/v1.PluginDTO"
+						}
+					},
+					"500": {
+						"description": "Bummer, something went wrong"
 					}
 				}
 			}
@@ -7144,7 +7653,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/map[string]interface%20%7B%7D"
+							"$ref": "#/definitions/v1.Properties"
 						}
 					},
 					"400": {
@@ -7490,7 +7999,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.ListTargetResponse"
 						}
 					},
 					"500": {
@@ -7524,9 +8033,9 @@
 				],
 				"responses": {
 					"200": {
-						"description": "OK",
+						"description": "create success",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.DetailTargetResponse"
 						}
 					},
 					"400": {
@@ -7567,9 +8076,9 @@
 				],
 				"responses": {
 					"200": {
-						"description": "OK",
+						"description": "create success",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.DetailTargetResponse"
 						}
 					},
 					"500": {
@@ -7612,7 +8121,7 @@
 					"200": {
 						"description": "OK",
 						"schema": {
-							"$ref": "#/definitions/v1.SimpleResponse"
+							"$ref": "#/definitions/v1.DetailTargetResponse"
 						}
 					},
 					"500": {
@@ -7632,7 +8141,7 @@
 				"tags": [
 					"Target"
 				],
-				"summary": "deletet Target",
+				"summary": "delete Target",
 				"operationId": "deleteTarget",
 				"parameters": [
 					{
@@ -8086,6 +8595,12 @@
 						"in": "query"
 					},
 					{
+						"type": "string",
+						"description": "The publish version for deploying application.if no specified, {application name}-v{the number of times it was published} (e.g.: demo-app-v13) will be used. the workflow record will use this value as the record identifier, so please ensure that this value is not duplicated if you specify it, otherwise the request will report an error",
+						"name": "publishVersion",
+						"in": "query"
+					},
+					{
 						"name": "body",
 						"in": "body",
 						"required": true,
@@ -8112,7 +8627,7 @@
 				"tags": [
 					"oam_application"
 				],
-				"summary": "create or update oam application in the specified namespace",
+				"summary": "delete oam application in the specified namespace",
 				"operationId": "deleteOAMApplication",
 				"parameters": [
 					{
@@ -8217,6 +8732,7 @@
 		}
 	},
 	"definitions": {
+		"*schema.UIParameter": {},
 		"*v1.ApplicationTriggerBase": {},
 		"*v1.Config": {},
 		"*v1.EmptyResponse": {},
@@ -8241,9 +8757,6 @@
 					"type": "boolean"
 				},
 				"runtimeCluster": {
-					"type": "boolean"
-				},
-				"runtime_cluster": {
 					"type": "boolean"
 				}
 			}
@@ -8315,6 +8828,12 @@
 				"invisible"
 			],
 			"properties": {
+				"annotations": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
 				"dependencies": {
 					"type": "array",
 					"items": {
@@ -8353,6 +8872,12 @@
 				},
 				"url": {
 					"type": "string"
+				},
+				"uxPlugins": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
 				},
 				"version": {
 					"type": "string"
@@ -8831,59 +9356,24 @@
 				}
 			}
 		},
-		"common.Helm": {
-			"required": [
-				"release",
-				"repository"
-			],
+		"common.HTTPOption": {
 			"properties": {
-				"release": {
+				"caFile": {
 					"type": "string"
 				},
-				"repository": {
-					"type": "string"
-				}
-			}
-		},
-		"common.Kube": {
-			"required": [
-				"template"
-			],
-			"properties": {
-				"parameters": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/common.KubeParameter"
-					}
-				},
-				"template": {
-					"type": "string"
-				}
-			}
-		},
-		"common.KubeParameter": {
-			"required": [
-				"name",
-				"type",
-				"fieldPaths"
-			],
-			"properties": {
-				"description": {
+				"certFile": {
 					"type": "string"
 				},
-				"fieldPaths": {
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				},
-				"name": {
-					"type": "string"
-				},
-				"required": {
+				"insecureSkipTLS": {
 					"type": "boolean"
 				},
-				"type": {
+				"keyFile": {
+					"type": "string"
+				},
+				"password": {
+					"type": "string"
+				},
+				"username": {
 					"type": "string"
 				}
 			}
@@ -8927,12 +9417,6 @@
 			"properties": {
 				"cue": {
 					"$ref": "#/definitions/common.CUE"
-				},
-				"helm": {
-					"$ref": "#/definitions/common.Helm"
-				},
-				"kube": {
-					"$ref": "#/definitions/common.Kube"
 				},
 				"terraform": {
 					"$ref": "#/definitions/common.Terraform"
@@ -9668,10 +10152,10 @@
 		},
 		"model.WorkflowStep": {
 			"required": [
-				"orderIndex",
-				"alias",
-				"type",
 				"description",
+				"orderIndex",
+				"type",
+				"alias",
 				"dependsOn",
 				"name"
 			],
@@ -9699,6 +10183,9 @@
 				},
 				"meta": {
 					"$ref": "#/definitions/v1alpha1.WorkflowStepMeta"
+				},
+				"mode": {
+					"type": "string"
 				},
 				"name": {
 					"type": "string"
@@ -10037,6 +10524,259 @@
 			}
 		},
 		"schema.Validate.defaultValue": {},
+		"types.BuildInfo": {
+			"properties": {
+				"branch": {
+					"type": "string"
+				},
+				"hash": {
+					"type": "string"
+				},
+				"repo": {
+					"type": "string"
+				},
+				"time": {
+					"type": "integer",
+					"format": "int64"
+				}
+			}
+		},
+		"types.Header": {
+			"required": [
+				"name",
+				"value"
+			],
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"value": {
+					"type": "string"
+				}
+			}
+		},
+		"types.Includes": {
+			"required": [
+				"name",
+				"label",
+				"to",
+				"type",
+				"icon",
+				"workspace",
+				"relatedRoute"
+			],
+			"properties": {
+				"catalog": {
+					"type": "string"
+				},
+				"icon": {
+					"type": "string"
+				},
+				"label": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"permission": {
+					"$ref": "#/definitions/types.Permission"
+				},
+				"relatedRoute": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"to": {
+					"type": "string"
+				},
+				"type": {
+					"type": "string"
+				},
+				"workspace": {
+					"$ref": "#/definitions/types.Workspace"
+				}
+			}
+		},
+		"types.Info": {
+			"required": [
+				"author",
+				"description",
+				"links",
+				"logos",
+				"build",
+				"screenshots",
+				"version",
+				"updated"
+			],
+			"properties": {
+				"author": {
+					"$ref": "#/definitions/types.InfoLink"
+				},
+				"build": {
+					"$ref": "#/definitions/types.BuildInfo"
+				},
+				"description": {
+					"type": "string"
+				},
+				"links": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/types.InfoLink"
+					}
+				},
+				"logos": {
+					"$ref": "#/definitions/types.Logos"
+				},
+				"screenshots": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/types.Screenshots"
+					}
+				},
+				"updated": {
+					"type": "string"
+				},
+				"version": {
+					"type": "string"
+				}
+			}
+		},
+		"types.InfoLink": {
+			"required": [
+				"name",
+				"url"
+			],
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"url": {
+					"type": "string"
+				}
+			}
+		},
+		"types.JSONData": {
+			"required": [
+				"id",
+				"type",
+				"subType",
+				"name",
+				"info",
+				"includes",
+				"category",
+				"backend",
+				"proxy",
+				"backendType",
+				"backendService"
+			],
+			"properties": {
+				"authSecret": {
+					"$ref": "#/definitions/types.KubernetesSecret"
+				},
+				"authType": {
+					"type": "string"
+				},
+				"backend": {
+					"type": "boolean"
+				},
+				"backendService": {
+					"$ref": "#/definitions/types.KubernetesService"
+				},
+				"backendType": {
+					"type": "string"
+				},
+				"category": {
+					"type": "string"
+				},
+				"id": {
+					"type": "string"
+				},
+				"includes": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/types.Includes"
+					}
+				},
+				"info": {
+					"$ref": "#/definitions/types.Info"
+				},
+				"kubePermissions": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/v1.PolicyRule"
+					}
+				},
+				"name": {
+					"type": "string"
+				},
+				"proxy": {
+					"type": "boolean"
+				},
+				"requirement": {
+					"$ref": "#/definitions/types.Requirement"
+				},
+				"routes": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/types.Route"
+					}
+				},
+				"subType": {
+					"type": "string"
+				},
+				"type": {
+					"type": "string"
+				}
+			}
+		},
+		"types.KubernetesSecret": {
+			"required": [
+				"name",
+				"namespace"
+			],
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"namespace": {
+					"type": "string"
+				}
+			}
+		},
+		"types.KubernetesService": {
+			"required": [
+				"name",
+				"namespace",
+				"port"
+			],
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"namespace": {
+					"type": "string"
+				},
+				"port": {
+					"type": "integer",
+					"format": "int32"
+				}
+			}
+		},
+		"types.Logos": {
+			"required": [
+				"small",
+				"large"
+			],
+			"properties": {
+				"large": {
+					"type": "string"
+				},
+				"small": {
+					"type": "string"
+				}
+			}
+		},
 		"types.NamespacedName": {
 			"required": [
 				"Namespace",
@@ -10047,6 +10787,20 @@
 					"type": "string"
 				},
 				"Namespace": {
+					"type": "string"
+				}
+			}
+		},
+		"types.Permission": {
+			"required": [
+				"resource",
+				"action"
+			],
+			"properties": {
+				"action": {
+					"type": "string"
+				},
+				"resource": {
 					"type": "string"
 				}
 			}
@@ -10064,6 +10818,59 @@
 				}
 			}
 		},
+		"types.Requirement": {
+			"required": [
+				"velauxVersion"
+			],
+			"properties": {
+				"velauxVersion": {
+					"type": "string"
+				}
+			}
+		},
+		"types.Route": {
+			"required": [
+				"path",
+				"method"
+			],
+			"properties": {
+				"headers": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/types.Header"
+					}
+				},
+				"method": {
+					"type": "string"
+				},
+				"path": {
+					"type": "string"
+				},
+				"permission": {
+					"$ref": "#/definitions/types.Permission"
+				},
+				"resourceMap": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"types.Screenshots": {
+			"required": [
+				"name",
+				"path"
+			],
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"path": {
+					"type": "string"
+				}
+			}
+		},
 		"types.SecretReference": {
 			"required": [
 				"name"
@@ -10073,6 +10880,16 @@
 					"type": "string"
 				},
 				"namespace": {
+					"type": "string"
+				}
+			}
+		},
+		"types.Workspace": {
+			"required": [
+				"name"
+			],
+			"properties": {
+				"name": {
 					"type": "string"
 				}
 			}
@@ -10216,6 +11033,16 @@
 		"v1.AddonStatusResponse.clusters": {
 			"type": "object"
 		},
+		"v1.AdminConfiguredResponse": {
+			"required": [
+				"configured"
+			],
+			"properties": {
+				"configured": {
+					"type": "boolean"
+				}
+			}
+		},
 		"v1.AppCompareReq": {
 			"properties": {
 				"compareLatestWithRunning": {
@@ -10314,6 +11141,12 @@
 				"alias": {
 					"type": "string"
 				},
+				"annotations": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
 				"createTime": {
 					"type": "string",
 					"format": "date-time"
@@ -10375,13 +11208,13 @@
 		},
 		"v1.ApplicationDeployResponse": {
 			"required": [
-				"status",
+				"workflowName",
 				"createTime",
-				"version",
 				"note",
 				"envName",
 				"triggerType",
-				"workflowName",
+				"version",
+				"status",
 				"record"
 			],
 			"properties": {
@@ -10559,6 +11392,19 @@
 				"workflowCount": {
 					"type": "integer",
 					"format": "int64"
+				}
+			}
+		},
+		"v1.ApplicationStatusListResponse": {
+			"required": [
+				"status"
+			],
+			"properties": {
+				"status": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/v1.ApplicationStatusResponse"
+					}
 				}
 			}
 		},
@@ -11118,6 +11964,12 @@
 				"os": {
 					"type": "string"
 				},
+				"os.features": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
 				"os.version": {
 					"type": "string"
 				},
@@ -11166,13 +12018,13 @@
 		},
 		"v1.ConfigTemplateDetail": {
 			"required": [
+				"description",
 				"scope",
 				"sensitive",
 				"createTime",
 				"alias",
 				"name",
 				"namespace",
-				"description",
 				"schema",
 				"uiSchema"
 			],
@@ -11919,10 +12771,14 @@
 				"icon",
 				"status",
 				"labels",
+				"category",
 				"ownerAddon"
 			],
 			"properties": {
 				"alias": {
+					"type": "string"
+				},
+				"category": {
 					"type": "string"
 				},
 				"component": {
@@ -11976,6 +12832,9 @@
 						"type": "string"
 					}
 				},
+				"artifactType": {
+					"type": "string"
+				},
 				"data": {
 					"type": "string"
 				},
@@ -12003,16 +12862,22 @@
 		"v1.DetailAddonResponse": {
 			"required": [
 				"name",
+				"invisible",
 				"version",
 				"description",
 				"icon",
-				"invisible",
 				"schema",
 				"uiSchema",
 				"definitions",
 				"availableVersions"
 			],
 			"properties": {
+				"annotations": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
 				"availableVersions": {
 					"type": "array",
 					"items": {
@@ -12079,6 +12944,12 @@
 				"url": {
 					"type": "string"
 				},
+				"uxPlugins": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
+				},
 				"version": {
 					"type": "string"
 				}
@@ -12086,13 +12957,13 @@
 		},
 		"v1.DetailApplicationResponse": {
 			"required": [
+				"updateTime",
+				"project",
 				"description",
 				"createTime",
-				"updateTime",
-				"icon",
-				"alias",
-				"project",
 				"name",
+				"alias",
+				"icon",
 				"policies",
 				"envBindings",
 				"resourceInfo"
@@ -12100,6 +12971,12 @@
 			"properties": {
 				"alias": {
 					"type": "string"
+				},
+				"annotations": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
 				},
 				"createTime": {
 					"type": "string",
@@ -12149,20 +13026,20 @@
 		},
 		"v1.DetailClusterResponse": {
 			"required": [
-				"apiServerURL",
-				"dashboardURL",
-				"labels",
-				"name",
-				"updateTime",
-				"alias",
-				"status",
 				"createTime",
-				"icon",
-				"reason",
-				"provider",
-				"kubeConfig",
-				"kubeConfigSecret",
 				"description",
+				"status",
+				"apiServerURL",
+				"kubeConfig",
+				"alias",
+				"icon",
+				"provider",
+				"updateTime",
+				"name",
+				"labels",
+				"reason",
+				"dashboardURL",
+				"kubeConfigSecret",
 				"resourceInfo"
 			],
 			"properties": {
@@ -12220,13 +13097,13 @@
 		},
 		"v1.DetailComponentResponse": {
 			"required": [
-				"updateTime",
-				"name",
-				"creator",
-				"alias",
-				"type",
 				"createTime",
+				"updateTime",
 				"appPrimaryKey",
+				"creator",
+				"name",
+				"type",
+				"alias",
 				"main",
 				"definition"
 			],
@@ -12315,18 +13192,22 @@
 		},
 		"v1.DetailDefinitionResponse": {
 			"required": [
-				"labels",
-				"name",
 				"alias",
+				"icon",
+				"labels",
+				"category",
+				"description",
 				"status",
 				"ownerAddon",
-				"description",
-				"icon",
+				"name",
 				"schema",
 				"uiSchema"
 			],
 			"properties": {
 				"alias": {
+					"type": "string"
+				},
+				"category": {
 					"type": "string"
 				},
 				"component": {
@@ -12378,15 +13259,15 @@
 		},
 		"v1.DetailPolicyResponse": {
 			"required": [
-				"properties",
-				"updateTime",
-				"envName",
 				"name",
-				"alias",
 				"type",
+				"updateTime",
+				"alias",
 				"description",
 				"creator",
-				"createTime"
+				"properties",
+				"createTime",
+				"envName"
 			],
 			"properties": {
 				"alias": {
@@ -12428,18 +13309,18 @@
 		},
 		"v1.DetailRevisionResponse": {
 			"required": [
-				"status",
-				"deployUser",
+				"updateTime",
 				"appPrimaryKey",
-				"version",
 				"revisionCRName",
-				"note",
 				"envName",
 				"createTime",
+				"version",
+				"status",
 				"reason",
+				"note",
 				"triggerType",
 				"workflowName",
-				"updateTime"
+				"deployUser"
 			],
 			"properties": {
 				"appPrimaryKey": {
@@ -12496,10 +13377,10 @@
 		},
 		"v1.DetailTargetResponse": {
 			"required": [
-				"createTime",
-				"updateTime",
 				"project",
-				"name"
+				"name",
+				"updateTime",
+				"createTime"
 			],
 			"properties": {
 				"alias": {
@@ -12571,7 +13452,7 @@
 				"projects": {
 					"type": "array",
 					"items": {
-						"$ref": "#/definitions/v1.ProjectBase"
+						"$ref": "#/definitions/v1.UserProjectBase"
 					}
 				},
 				"roles": {
@@ -12584,13 +13465,13 @@
 		},
 		"v1.DetailWorkflowRecordResponse": {
 			"required": [
-				"status",
 				"message",
-				"mode",
 				"name",
+				"applicationRevision",
 				"namespace",
 				"workflowAlias",
-				"applicationRevision",
+				"status",
+				"mode",
 				"workflowName",
 				"deployTime",
 				"deployUser",
@@ -12653,16 +13534,16 @@
 		},
 		"v1.DetailWorkflowResponse": {
 			"required": [
-				"name",
-				"alias",
-				"description",
-				"default",
-				"subMode",
 				"enable",
 				"envName",
 				"createTime",
+				"subMode",
+				"name",
+				"description",
 				"updateTime",
-				"mode"
+				"mode",
+				"alias",
+				"default"
 			],
 			"properties": {
 				"alias": {
@@ -12897,12 +13778,12 @@
 		},
 		"v1.GetPipelineResponse": {
 			"required": [
+				"description",
+				"createTime",
+				"spec",
 				"name",
 				"alias",
 				"project",
-				"spec",
-				"description",
-				"createTime",
 				"info"
 			],
 			"properties": {
@@ -12945,10 +13826,10 @@
 		},
 		"v1.GetPipelineRunLogResponse": {
 			"required": [
+				"phase",
 				"id",
 				"name",
 				"type",
-				"phase",
 				"source",
 				"log"
 			],
@@ -12988,8 +13869,14 @@
 		},
 		"v1.HandleApplicationTriggerWebhookRequest": {
 			"properties": {
+				"action": {
+					"type": "string"
+				},
 				"codeInfo": {
 					"$ref": "#/definitions/model.CodeInfo"
+				},
+				"step": {
+					"type": "string"
 				},
 				"upgrade": {
 					"type": "object",
@@ -13112,6 +13999,34 @@
 				}
 			}
 		},
+		"v1.InitAdminRequest": {
+			"required": [
+				"name",
+				"password",
+				"email"
+			],
+			"properties": {
+				"email": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"password": {
+					"type": "string"
+				}
+			}
+		},
+		"v1.InitAdminResponse": {
+			"required": [
+				"success"
+			],
+			"properties": {
+				"success": {
+					"type": "boolean"
+				}
+			}
+		},
 		"v1.InputVar": {
 			"required": [
 				"from",
@@ -13130,6 +14045,22 @@
 					"type": "string"
 				},
 				"value": {
+					"type": "string"
+				}
+			}
+		},
+		"v1.InstallPluginRequest": {
+			"required": [
+				"url"
+			],
+			"properties": {
+				"disable": {
+					"type": "boolean"
+				},
+				"options": {
+					"$ref": "#/definitions/common.HTTPOption"
+				},
+				"url": {
 					"type": "string"
 				}
 			}
@@ -13417,6 +14348,19 @@
 				}
 			}
 		},
+		"v1.ListPluginResponse": {
+			"required": [
+				"plugins"
+			],
+			"properties": {
+				"plugins": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/v1.PluginDTO"
+					}
+				}
+			}
+		},
 		"v1.ListProjectResponse": {
 			"required": [
 				"projects",
@@ -13602,11 +14546,11 @@
 		},
 		"v1.LoginUserInfoResponse": {
 			"required": [
-				"createTime",
 				"lastLoginTime",
 				"name",
 				"email",
 				"disabled",
+				"createTime",
 				"projects",
 				"platformPermissions",
 				"projectPermissions"
@@ -13650,8 +14594,113 @@
 				"projects": {
 					"type": "array",
 					"items": {
-						"$ref": "#/definitions/v1.ProjectBase"
+						"$ref": "#/definitions/v1.UserProjectBase"
 					}
+				}
+			}
+		},
+		"v1.ManagedPluginDTO": {
+			"required": [
+				"subType",
+				"info",
+				"includes",
+				"backendService",
+				"backend",
+				"type",
+				"category",
+				"backendType",
+				"id",
+				"name",
+				"proxy",
+				"class",
+				"defaultNavURL",
+				"module",
+				"baseURL",
+				"enabled",
+				"jsonSetting",
+				"secureJsonFields"
+			],
+			"properties": {
+				"authSecret": {
+					"$ref": "#/definitions/types.KubernetesSecret"
+				},
+				"authType": {
+					"type": "string"
+				},
+				"backend": {
+					"type": "boolean"
+				},
+				"backendService": {
+					"$ref": "#/definitions/types.KubernetesService"
+				},
+				"backendType": {
+					"type": "string"
+				},
+				"baseURL": {
+					"type": "string"
+				},
+				"category": {
+					"type": "string"
+				},
+				"class": {
+					"type": "string"
+				},
+				"defaultNavURL": {
+					"type": "string"
+				},
+				"enabled": {
+					"type": "boolean"
+				},
+				"id": {
+					"type": "string"
+				},
+				"includes": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/types.Includes"
+					}
+				},
+				"info": {
+					"$ref": "#/definitions/types.Info"
+				},
+				"jsonSetting": {
+					"type": "object"
+				},
+				"kubePermissions": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/v1.PolicyRule"
+					}
+				},
+				"module": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"proxy": {
+					"type": "boolean"
+				},
+				"requirement": {
+					"$ref": "#/definitions/types.Requirement"
+				},
+				"routes": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/types.Route"
+					}
+				},
+				"secureJsonFields": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "boolean"
+					}
+				},
+				"subType": {
+					"type": "string"
+				},
+				"type": {
+					"type": "string"
 				}
 			}
 		},
@@ -13683,6 +14732,9 @@
 				"schemaVersion": {
 					"type": "integer",
 					"format": "int64"
+				},
+				"subject": {
+					"$ref": "#/definitions/v1.Descriptor"
 				}
 			}
 		},
@@ -13808,11 +14860,11 @@
 		},
 		"v1.PipelineBase": {
 			"required": [
-				"description",
-				"createTime",
 				"name",
 				"alias",
 				"project",
+				"description",
+				"createTime",
 				"spec"
 			],
 			"properties": {
@@ -13911,11 +14963,11 @@
 		},
 		"v1.PipelineMetaResponse": {
 			"required": [
+				"alias",
 				"project",
 				"description",
 				"createTime",
-				"name",
-				"alias"
+				"name"
 			],
 			"properties": {
 				"alias": {
@@ -13938,13 +14990,13 @@
 		},
 		"v1.PipelineRun": {
 			"required": [
+				"contextValues",
 				"spec",
 				"project",
 				"pipelineRunName",
 				"pipelineName",
 				"record",
 				"contextName",
-				"contextValues",
 				"status"
 			],
 			"properties": {
@@ -14107,6 +15159,69 @@
 				}
 			}
 		},
+		"v1.PluginDTO": {
+			"required": [
+				"id",
+				"type",
+				"subType",
+				"name",
+				"info",
+				"includes",
+				"category",
+				"defaultNavURL",
+				"module",
+				"baseURL"
+			],
+			"properties": {
+				"baseURL": {
+					"type": "string"
+				},
+				"category": {
+					"type": "string"
+				},
+				"defaultNavURL": {
+					"type": "string"
+				},
+				"id": {
+					"type": "string"
+				},
+				"includes": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/types.Includes"
+					}
+				},
+				"info": {
+					"$ref": "#/definitions/types.Info"
+				},
+				"module": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"subType": {
+					"type": "string"
+				},
+				"type": {
+					"type": "string"
+				}
+			}
+		},
+		"v1.PluginEnableRequest": {
+			"required": [
+				"jsonData",
+				"secureJsonData"
+			],
+			"properties": {
+				"jsonData": {
+					"type": "object"
+				},
+				"secureJsonData": {
+					"type": "object"
+				}
+			}
+		},
 		"v1.PolicyBase": {
 			"required": [
 				"name",
@@ -14148,6 +15263,49 @@
 				"updateTime": {
 					"type": "string",
 					"format": "date-time"
+				}
+			}
+		},
+		"v1.PolicyRule": {
+			"description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
+			"required": [
+				"verbs"
+			],
+			"properties": {
+				"apiGroups": {
+					"description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. \"\" represents the core API group and \"*\" represents all API groups.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"nonResourceURLs": {
+					"description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"resourceNames": {
+					"description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"resources": {
+					"description": "Resources is a list of resources this rule applies to. '*' represents all resources.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"verbs": {
+					"description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
 				}
 			}
 		},
@@ -14216,6 +15374,9 @@
 					}
 				}
 			}
+		},
+		"v1.Properties": {
+			"type": "object"
 		},
 		"v1.PutApplicationEnvBindingRequest": {},
 		"v1.RefreshTokenResponse": {
@@ -14455,10 +15616,10 @@
 		},
 		"v1.StepOutputBase": {
 			"required": [
+				"id",
 				"name",
 				"type",
 				"phase",
-				"id",
 				"values"
 			],
 			"properties": {
@@ -14541,9 +15702,9 @@
 		},
 		"v1.SystemInfoResponse": {
 			"required": [
+				"platformID",
 				"enableCollection",
 				"loginType",
-				"platformID",
 				"systemVersion"
 			],
 			"properties": {
@@ -14714,6 +15875,12 @@
 			"properties": {
 				"alias": {
 					"type": "string"
+				},
+				"annotations": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					}
 				},
 				"description": {
 					"type": "string"
@@ -14991,6 +16158,39 @@
 				}
 			}
 		},
+		"v1.UserProjectBase": {
+			"required": [
+				"name",
+				"alias",
+				"description",
+				"joinTime",
+				"roles"
+			],
+			"properties": {
+				"alias": {
+					"type": "string"
+				},
+				"description": {
+					"type": "string"
+				},
+				"joinTime": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"name": {
+					"type": "string"
+				},
+				"owner": {
+					"$ref": "#/definitions/v1.NameAlias"
+				},
+				"roles": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/v1.NameAlias"
+					}
+				}
+			}
+		},
 		"v1.VelaQLViewResponse": {
 			"type": "object"
 		},
@@ -15067,14 +16267,14 @@
 		},
 		"v1.WorkflowRecord": {
 			"required": [
-				"name",
-				"workflowName",
-				"status",
 				"message",
+				"name",
+				"workflowAlias",
+				"applicationRevision",
+				"status",
 				"mode",
 				"namespace",
-				"workflowAlias",
-				"applicationRevision"
+				"workflowName"
 			],
 			"properties": {
 				"applicationRevision": {
@@ -15192,6 +16392,9 @@
 				},
 				"meta": {
 					"$ref": "#/definitions/v1alpha1.WorkflowStepMeta"
+				},
+				"mode": {
+					"type": "string"
 				},
 				"name": {
 					"type": "string"
@@ -15439,6 +16642,9 @@
 				"meta": {
 					"$ref": "#/definitions/v1alpha1.WorkflowStepMeta"
 				},
+				"mode": {
+					"type": "string"
+				},
 				"name": {
 					"type": "string"
 				},
@@ -15554,7 +16760,6 @@
 		},
 		"v1beta1.AppPolicy": {
 			"required": [
-				"name",
 				"type"
 			],
 			"properties": {

--- a/packages/velaux-ui/src/pages/Cluster/index.tsx
+++ b/packages/velaux-ui/src/pages/Cluster/index.tsx
@@ -101,7 +101,7 @@ class Cluster extends React.Component<Props, State> {
       (enableAddon || []).forEach((ele: { name: string; phase: boolean }) => {
         addonList.forEach((item: Addon) => {
           const isMatchName = ele.name === item.name;
-          const deploy = item.deployTo || { runtimeCluster: false, runtime_cluster: false };
+          const deploy = item.deployTo || { runtimeCluster: false };
           if (isMatchName && deploy.runtimeCluster) {
             addonMessage.push({ name: item.name, path: item.url || '' });
           }

--- a/pkg/server/interfaces/api/plugin.go
+++ b/pkg/server/interfaces/api/plugin.go
@@ -121,7 +121,7 @@ func (p *ManagePlugin) GetWebServiceRoute() *restful.WebService {
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Filter(p.RBACService.CheckPerm("managePlugin", "enable")).
 		Param(ws.PathParameter("pluginId", "identifier of the plugin.").DataType("string")).
-		Returns(200, "OK", struct{}{}).
+		Returns(200, "OK", apis.EmptyResponse{}).
 		Writes(apis.PluginDTO{}).Do(returns500))
 
 	ws.Route(ws.POST("/{pluginId}/enable").To(p.enablePlugin).

--- a/pkg/server/interfaces/api/repository.go
+++ b/pkg/server/interfaces/api/repository.go
@@ -115,7 +115,7 @@ func (h repository) GetWebServiceRoute() *restful.WebService {
 		Param(ws.PathParameter("version", "version of the helm chart").DataType("string").Required(true)).
 		Param(ws.QueryParameter("repoUrl", "helm repository url").DataType("string")).
 		Param(ws.QueryParameter("secretName", "secret of the repo").DataType("string")).
-		Returns(200, "OK", map[string]interface{}{}).
+		Returns(200, "OK", v1.Properties{}).
 		Returns(400, "Bad Request", bcode.Bcode{}).
 		Writes(map[string]interface{}{}))
 


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

* Update swagger.json by `make build-swagger`.
* Returns a predefined structure instead of a map object to avoid Swagger being unable to generate code correctly
* Delete duplicate runtimes_cluster parameter definition to avoid the code constructed by swagger being unusable
* Add swagger 3.0.json to facilitate developers debugging APIs on the swagger UI (BearerAuth only available in swagger 3.0+).
![image](https://github.com/kubevela/velaux/assets/2259715/d10fba87-001d-4138-abe7-9897e0834db4)


Fixes #713 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [x] Run `make reviewable`to ensure the server changes are ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
