### PR TITLE
Chore: replace deprecated command with environment file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         if [[ ${GITHUB_REF} == "refs/heads/main" ]]; then
           VERSION=latest
         fi
-        echo ::set-output name=VERSION::${VERSION}
+        echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
     - name: Get git revision
       id: vars
       shell: bash


### PR DESCRIPTION
### Description of your changes

Closes #894 

Update `.github/workflows/release.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo ::set-output name=VERSION::${VERSION}
```

**TO-BE**

```yaml
echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
```

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

None
<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
