### PR TITLE
Fix: Username length in projects users to match users

### DIFF
--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -110,7 +110,7 @@ jobs:
     if: needs.detect-noop.outputs.noop != 'true'
     strategy:
       matrix:
-        k8s-version: ["v1.21", "v1.26"]
+        k8s-version: ["v1.26"]
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.k8s-version }}
       cancel-in-progress: true

--- a/pkg/server/domain/service/authentication.go
+++ b/pkg/server/domain/service/authentication.go
@@ -449,12 +449,12 @@ func (a *authenticationServiceImpl) GetLoginType(ctx context.Context) (*apisv1.G
 	}, nil
 }
 
-func getSub(claims *model.Claims) string {
-	sub := strings.ToLower(claims.Sub)
+func getUserName(sub string) string {
+	username := strings.ToLower(sub)
 	if len(sub) > datastore.PrimaryKeyMaxLength {
 		return sub[:datastore.PrimaryKeyMaxLength]
 	}
-	return sub
+	return username
 }
 
 func (d *dexHandlerImpl) login(ctx context.Context) (*apisv1.UserBase, error) {
@@ -501,7 +501,7 @@ func (d *dexHandlerImpl) login(ctx context.Context) (*apisv1.UserBase, error) {
 		}
 		user := &model.User{
 			Email:         claims.Email,
-			Name:          getSub(claims),
+			Name:          getUserName(claims.Sub),
 			DexSub:        claims.Sub,
 			Alias:         claims.Name,
 			LastLoginTime: time.Now(),
@@ -516,7 +516,7 @@ func (d *dexHandlerImpl) login(ctx context.Context) (*apisv1.UserBase, error) {
 		if systemInfo != nil {
 			for _, project := range systemInfo.DexUserDefaultProjects {
 				_, err := d.projectService.AddProjectUser(ctx, project.Name, apisv1.AddProjectUserRequest{
-					UserName:  getSub(claims),
+					UserName:  getUserName(claims.Sub),
 					UserRoles: project.Roles,
 				})
 				if err != nil {


### PR DESCRIPTION
### Description of your changes

1. "Fixes #903": SSO user default project not getting set because the username vela_user.name doesn't have the same length as the username FK in vela_project_user 
   This means users logging in have no permissions whatsoever unless someone manually adds it.

2. The e2e tests were failing due to k3s version 1.21 not being available. I've removed the version from the matrix

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [x] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [x] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
