### PR TITLE
Fix: Prevent crashes when accessing cluster details

### DIFF
--- a/packages/velaux-ui/src/pages/Cluster/components/AddClusterDialog/index.tsx
+++ b/packages/velaux-ui/src/pages/Cluster/components/AddClusterDialog/index.tsx
@@ -55,7 +55,7 @@ class AddClusterDialog extends React.Component<Props, State> {
       });
     }
   };
-
+  
   onClose = () => {
     this.props.onClose();
     this.resetField();
@@ -69,13 +69,13 @@ class AddClusterDialog extends React.Component<Props, State> {
       }
       if (editMode) {
         updateCluster({
-          name: cluster.name,
+          name: cluster?.name,
           alias: values.alias,
-          icon: cluster.icon,
+          icon: cluster?.icon,
           description: values.description,
           dashboardURL: values.dashboardURL,
           kubeConfig: values.kubeConfig,
-          labels: cluster.labels,
+          labels: cluster?.labels,
         }).then((re: any) => {
           if (re) {
             Message.success(<Translation>cluster update success</Translation>);
@@ -140,7 +140,7 @@ class AddClusterDialog extends React.Component<Props, State> {
     };
     const init = this.field.init;
     const values: { kubeConfig: string } = this.field.getValues();
-    const valueInfo = cluster.kubeConfig || values.kubeConfig || '';
+    const valueInfo = cluster?.kubeConfig || values.kubeConfig || '';
     return (
       <Dialog
         locale={locale().Dialog}
@@ -170,7 +170,7 @@ class AddClusterDialog extends React.Component<Props, State> {
                     name="name"
                     disabled={editMode}
                     {...init('name', {
-                      initValue: cluster.name,
+                      initValue: cluster?.name || editClusterName,
                       rules: [
                         {
                           required: true,
@@ -187,7 +187,7 @@ class AddClusterDialog extends React.Component<Props, State> {
                   <Input
                     name="alias"
                     {...init('alias', {
-                      initValue: cluster.alias,
+                      initValue: cluster?.alias,
                       rules: [
                         {
                           minLength: 2,
@@ -204,10 +204,10 @@ class AddClusterDialog extends React.Component<Props, State> {
               <Col span={12} style={{ padding: '0 8px' }}>
                 <FormItem label={<Translation>Description</Translation>}>
                   <Input
-                    defaultValue={cluster.description}
+                    defaultValue={cluster?.description}
                     name="description"
                     {...init('description', {
-                      initValue: cluster.description,
+                      initValue: cluster?.description,
                       rules: [
                         {
                           maxLength: 256,
@@ -223,7 +223,7 @@ class AddClusterDialog extends React.Component<Props, State> {
                   <Input
                     name="dashboardURL"
                     {...init('dashboardURL', {
-                      initValue: cluster.dashboardURL,
+                      initValue: cluster?.dashboardURL,
                       rules: [
                         {
                           required: false,
@@ -252,7 +252,7 @@ class AddClusterDialog extends React.Component<Props, State> {
                       language={'yaml'}
                       readOnly={false}
                       {...init('kubeConfig', {
-                        initValue: cluster.kubeConfig,
+                        initValue: cluster?.kubeConfig,
                         rules: [
                           {
                             required: true,


### PR DESCRIPTION
- Added optional chaining to safely access cluster details in `AddClusterDialog`.

This fix addresses the issue where the page crashes when trying to load details for an inaccessible cluster.

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #685

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
