### PR TITLE
Fix: Set default values for traits in VelaUX

### DIFF
--- a/packages/velaux-ui/src/components/UISchema/index.tsx
+++ b/packages/velaux-ui/src/components/UISchema/index.tsx
@@ -134,6 +134,7 @@ class UISchema extends Component<Props, State> {
     if (this.props.registerForm) {
       this.props.registerForm(this.form);
     }
+    this.initFormValues();
     this.state = {
       secretKeys: [],
       advanced: props.advanced || false,
@@ -174,6 +175,32 @@ class UISchema extends Component<Props, State> {
       }
       callback();
     });
+  };
+
+  initFormValues = () => {
+    // Extract default values from the UI schema
+    const extractDefaultValues = (uiSchema) => {
+      const initialValues = {};
+      
+      // Loop through the UI schema and extract default values
+      uiSchema?.forEach((param) => {
+        if (param.validate?.defaultValue !== undefined) {
+          initialValues[param.jsonKey] = param.validate.defaultValue;
+        }
+      });
+  
+      return initialValues;
+    };
+  
+    const defaultValues = extractDefaultValues(this.props.uiSchema);
+  
+    // Initialize the form with default values
+    if (defaultValues) {
+      const { onChange } = this.props;
+      if (onChange) {
+        onChange(defaultValues);
+      }
+    }
   };
 
   conditionAllowRender = (conditions?: ParamCondition[]) => {


### PR DESCRIPTION
- Addressed the issue where default values for traits (including "cpuscaler", "hpa", "resource", "k8s-update-strategy") were not being set properly.

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #650

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->

Traits with default values, such as "cpuscaler," "hpa," "resource," and "k8s-update-strategy," require some input to trigger the onChange event before the properties can be set correctly. To address this, I called onChange during the initialization phase to ensure the default values are set properly.

I realize that this approach may not be the most elegant solution, so I'm open to any suggestions for a better implementation or alternative ways to handle default values more effectively.
