### PR TITLE
Fix: Set default values for traits in VelaUX

### DIFF
--- a/packages/velaux-ui/src/pages/ApplicationConfig/components/TraitDialog/index.tsx
+++ b/packages/velaux-ui/src/pages/ApplicationConfig/components/TraitDialog/index.tsx
@@ -195,12 +195,26 @@ class TraitDialog extends React.Component<Props, State> {
       .then((re) => {
         if (re) {
           this.setState({ definitionDetail: re, definitionLoading: false });
-          if (callback) {
-            callback();
-          }
+          this.setDefaultProperties(re)
+            if (callback) {
+              callback();
+            }
         }
       })
       .catch(() => this.setState({ definitionLoading: false }));
+  };
+
+  setDefaultProperties = (definitionDetail: any) => {
+    const properties = definitionDetail.schema?.properties;
+    if (properties) {
+        const defaultValues: Record<string, any> = {};
+        for (const key in properties) {
+            if (properties[key].default !== undefined) {
+                defaultValues[key] = properties[key].default;
+            }
+        }
+        this.field.setValues({ properties: defaultValues });
+    }
   };
 
   handleTypeChange = (value: string) => {


### PR DESCRIPTION
- Addressed the issue where default values for traits (including "cpuscaler", "hpa", "resource", "k8s-update-strategy") were not being set properly.

### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #650

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [x] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->
