### PR TITLE
Fix: password validation regex to allow special characters #931

### DIFF
--- a/packages/velaux-ui/src/layout/Header/components/EditPlatFormUserDialog/index.tsx
+++ b/packages/velaux-ui/src/layout/Header/components/EditPlatFormUserDialog/index.tsx
@@ -139,7 +139,7 @@ class EditPlatFormUserDialog extends Component<Props, State> {
                           pattern: checkUserPassword,
                           message: (
                             <Translation>
-                                Password must be alphanumeric, contain at least one letter and one number, and be 8-16 characters long
+                                Password must contain at least one letter and one number, and be 8-16 characters long
                             </Translation>
                           ),
                         },

--- a/packages/velaux-ui/src/pages/Users/components/CreateUser/index.tsx
+++ b/packages/velaux-ui/src/pages/Users/components/CreateUser/index.tsx
@@ -209,7 +209,7 @@ class CreateUser extends React.Component<Props, State> {
                             pattern: checkUserPassword,
                             message: (
                               <Translation>
-                                Password must be alphanumeric, contain at least one letter and one number, and be 8-16 characters long
+                                Password must contain at least one letter and one number, and be 8-16 characters long
                               </Translation>
                             ),
                           },

--- a/packages/velaux-ui/src/pages/Users/components/ResetPassword/index.tsx
+++ b/packages/velaux-ui/src/pages/Users/components/ResetPassword/index.tsx
@@ -117,7 +117,7 @@ class ResetPassword extends React.Component<Props, State> {
                           pattern: checkUserPassword,
                           message: (
                             <Translation>
-                              Password must be alphanumeric, contain at least one letter and one number, and be 8-16 characters long
+                              Password must contain at least one letter and one number, and be 8-16 characters long
                             </Translation>
                           ),
                         },

--- a/packages/velaux-ui/src/utils/common.ts
+++ b/packages/velaux-ui/src/utils/common.ts
@@ -229,7 +229,7 @@ export const replaceUrl = function (text: string) {
   return str;
 };
 
-export const checkUserPassword = /^(?=.*[0-9])(?=.*[a-zA-Z])([a-zA-Z0-9]{8,16})$/;
+export const checkUserPassword = /^(?=.*[0-9])(?=.*[a-zA-Z])(.{8,16})$/;
 
 export function isMatchBusinessCode(businessCode: number) {
   const tokenExpiredList = [12002, 12010];


### PR DESCRIPTION
### Description of your changes
The old regex explicitly forced the 8-16 characters to be alphanumeric only:

`export const checkUserPassword = /^(?=.*[0-9])(?=.*[a-zA-Z])([a-zA-Z0-9]{8,16})$/;`

Updating the regex to allow any character (including symbols) for the 8-16 characters resolves the issue:

`export const checkUserPassword = /^(?=.*[0-9])(?=.*[a-zA-Z])(.{8,16})$/;`

Fixes#929




Fixes #

I have:

- [ ] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/velaux/pull/932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

