### PR TITLE
feat: implement OIDC group to project role mappings

### DIFF
--- a/packages/velaux-data/src/api/group_mapping.ts
+++ b/packages/velaux-data/src/api/group_mapping.ts
@@ -1,0 +1,12 @@
+export interface GroupProjectRoleBase {
+  project: string;
+  role: string;
+}
+
+export interface GroupMappingResponse {
+  groups: Record<string, GroupProjectRoleBase[]>;
+}
+
+export interface UpdateGroupMappingRequest {
+  groups: Record<string, GroupProjectRoleBase[]>;
+}

--- a/packages/velaux-data/src/api/index.ts
+++ b/packages/velaux-data/src/api/index.ts
@@ -14,3 +14,4 @@ export * from './roles';
 export * from './system';
 export * from './target';
 export * from './user';
+export * from './group_mapping';

--- a/packages/velaux-ui/src/api/group_mapping.ts
+++ b/packages/velaux-ui/src/api/group_mapping.ts
@@ -1,0 +1,17 @@
+import type { GroupMappingResponse, UpdateGroupMappingRequest } from '@velaux/data';
+import { getDomain } from '../utils/common';
+
+import { groupMappings } from './productionLink';
+import { get, put } from './request';
+
+const baseURLObject = getDomain();
+const isMock = baseURLObject.MOCK;
+const url = isMock ? '/mock/group_mappings' : groupMappings;
+
+export function getGroupMappings() {
+  return get(url, {}).then((res: GroupMappingResponse) => res);
+}
+
+export function updateGroupMappings(params: UpdateGroupMappingRequest) {
+  return put(url, params).then((res: GroupMappingResponse) => res);
+}

--- a/packages/velaux-ui/src/api/productionLink.ts
+++ b/packages/velaux-ui/src/api/productionLink.ts
@@ -25,3 +25,4 @@ export const configTemplates = `/api/v1/config_templates`;
 export const cloudShell = `/api/v1/cloudshell`;
 export const plugin = `/api/v1/plugins`;
 export const managePlugin = `/api/v1/manage/plugins`;
+export const groupMappings = `/api/v1/group_mappings`;

--- a/packages/velaux-ui/src/layout/LayoutRouter/index.tsx
+++ b/packages/velaux-ui/src/layout/LayoutRouter/index.tsx
@@ -16,6 +16,7 @@ import Clusters from '../../pages/Cluster/index';
 import Configs from '../../pages/Configs';
 import Definitions from '../../pages/Definitions';
 import EnvPage from '../../pages/EnvPage';
+import GroupMappings from '../../pages/GroupMappings';
 import NotFound from '../../pages/NotFound';
 import PipelineListPage from '../../pages/PipelineListPage';
 import PipelineRunPage from '../../pages/PipelineRunPage';
@@ -393,9 +394,16 @@ export default function Router() {
         }}
       />
       <Route
+        exact={true}
         path="/settings"
         render={(props: any) => {
           return <PlatformSetting {...props}></PlatformSetting>;
+        }}
+      />
+      <Route
+        path="/settings/group-mappings"
+        render={(props: any) => {
+          return <GroupMappings {...props}></GroupMappings>;
         }}
       />
       <Route

--- a/packages/velaux-ui/src/pages/GroupMappings/index.tsx
+++ b/packages/velaux-ui/src/pages/GroupMappings/index.tsx
@@ -1,0 +1,266 @@
+import { Button, Field, Form, Grid, Input, Message, Select } from '@alifd/next';
+import React from 'react';
+import { AiOutlineDelete, AiOutlinePlus } from 'react-icons/ai';
+import { v4 as uuid } from 'uuid';
+
+import { getGroupMappings, updateGroupMappings } from '../../api/group_mapping';
+import { getProjectList, getProjectRoles } from '../../api/project';
+import { ListTitle as Title } from '../../components/ListTitle';
+import { Translation } from '../../components/Translation';
+import i18n from '../../i18n';
+import type { Project, ProjectRoleBase, GroupProjectRoleBase } from '@velaux/data';
+
+const { Row, Col } = Grid;
+const FormItem = Form.Item;
+
+type Props = {};
+
+type GroupItem = {
+  id: string;
+  group: string;
+  project: string;
+  role: string;
+};
+
+type State = {
+  mappingItems: GroupItem[];
+  projects: Project[];
+  projectRoles: Record<string, ProjectRoleBase[]>;
+  isLoading: boolean;
+};
+
+class GroupMappings extends React.Component<Props, State> {
+  field: Field;
+
+  constructor(props: Props) {
+    super(props);
+    this.field = new Field(this);
+    this.state = {
+      mappingItems: [],
+      projects: [],
+      projectRoles: {},
+      isLoading: false,
+    };
+  }
+
+  componentDidMount() {
+    this.listProjects();
+    this.loadGroupMappings();
+  }
+
+  listProjects = async () => {
+    try {
+      const res = await getProjectList({ page: 0, pageSize: 0 });
+      this.setState({ projects: res.projects || [] });
+      // Pre-fetch roles for all projects to make the UI responsive
+      if (res.projects) {
+        res.projects.forEach((p: Project) => {
+          this.loadProjectRoles(p.name);
+        });
+      }
+    } catch (e) {
+      // ignore
+    }
+  };
+
+  loadProjectRoles = async (projectName: string) => {
+    if (this.state.projectRoles[projectName]) {
+      return;
+    }
+    try {
+      const res = await getProjectRoles({ projectName });
+      this.setState((prevState) => ({
+        projectRoles: {
+          ...prevState.projectRoles,
+          [projectName]: res?.roles || [],
+        },
+      }));
+    } catch (e) {
+      // ignore
+    }
+  };
+
+  loadGroupMappings = async () => {
+    this.setState({ isLoading: true });
+    try {
+      const res = await getGroupMappings();
+      const items: GroupItem[] = [];
+      if (res && res.groups) {
+        Object.keys(res.groups).forEach((group) => {
+          res.groups[group].forEach((pr: GroupProjectRoleBase) => {
+            items.push({
+              id: uuid(),
+              group: group,
+              project: pr.project,
+              role: pr.role,
+            });
+          });
+        });
+      }
+      this.setState({ mappingItems: items, isLoading: false });
+      
+      // Initialize field values
+      items.forEach((item) => {
+        this.field.setValue(`${item.id}-group`, item.group);
+        this.field.setValue(`${item.id}-project`, item.project);
+        this.field.setValue(`${item.id}-role`, item.role);
+      });
+    } catch (e) {
+      this.setState({ isLoading: false });
+    }
+  };
+
+  onAddItem = () => {
+    const newItem = { id: uuid(), group: '', project: '', role: '' };
+    this.setState((prevState) => ({
+      mappingItems: [...prevState.mappingItems, newItem],
+    }));
+  };
+
+  onRemoveItem = (id: string) => {
+    this.setState((prevState) => ({
+      mappingItems: prevState.mappingItems.filter((item) => item.id !== id),
+    }));
+    this.field.remove(`${id}-group`);
+    this.field.remove(`${id}-project`);
+    this.field.remove(`${id}-role`);
+  };
+
+  generateProjectOptions = () => {
+    return this.state.projects?.map((item) => {
+      return {
+        label: `${item.name}(${item.alias || '-'})`,
+        value: item.name,
+      };
+    });
+  };
+
+  generateProjectRoleOptions = (projectName: string) => {
+    const roles = this.state.projectRoles[projectName] || [];
+    return roles.map((item) => {
+      return {
+        label: `${item.name}(${item.alias || '-'})`,
+        value: item.name,
+      };
+    });
+  };
+
+  onSubmit = () => {
+    this.field.validate((errs: any, values: Record<string, any>) => {
+      if (errs) {
+        return;
+      }
+      
+      const { mappingItems } = this.state;
+      const groupsMap: Record<string, GroupProjectRoleBase[]> = {};
+      
+      mappingItems.forEach((item) => {
+        const group = values[`${item.id}-group`];
+        const project = values[`${item.id}-project`];
+        const role = values[`${item.id}-role`];
+        
+        if (group && project && role) {
+          if (!groupsMap[group]) {
+            groupsMap[group] = [];
+          }
+          groupsMap[group].push({ project, role });
+        }
+      });
+      
+      this.setState({ isLoading: true });
+      updateGroupMappings({ groups: groupsMap })
+        .then((res) => {
+          Message.success(i18n.t('Group mappings updated successfully'));
+          this.setState({ isLoading: false });
+        })
+        .catch((err) => {
+          Message.error(err?.Message || i18n.t('Failed to update group mappings'));
+          this.setState({ isLoading: false });
+        });
+    });
+  };
+
+  render() {
+    const { mappingItems, isLoading } = this.state;
+    const { init, getValue } = this.field;
+
+    return (
+      <div>
+        <Title
+          title={i18n.t('OIDC Group Mappings').toString()}
+          subTitle={i18n.t('Configure OIDC group to project role mappings. These map OIDC group claims to project roles dynamically upon login.').toString()}
+          extButtons={[
+            <Button key="save" type="primary" onClick={this.onSubmit} loading={isLoading}>
+              <Translation>Save</Translation>
+            </Button>
+          ]}
+        />
+        <div className="margin-top-20" style={{ padding: '0 20px' }}>
+          <Form field={this.field}>
+              {mappingItems.map((item, index) => {
+                const projectValue = getValue(`${item.id}-project`) as string;
+                return (
+                  <Row key={item.id} gutter={16} className="margin-bottom-10">
+                    <Col span={7}>
+                      <FormItem required>
+                        <Input
+                          {...init(`${item.id}-group`, {
+                            rules: [{ required: true, message: 'Group name is required' }],
+                          })}
+                          placeholder={i18n.t('OIDC Group Name').toString()}
+                        />
+                      </FormItem>
+                    </Col>
+                    <Col span={7}>
+                      <FormItem required>
+                        <Select
+                          {...init(`${item.id}-project`, {
+                            rules: [{ required: true, message: 'Project is required' }],
+                          })}
+                          placeholder={i18n.t('Select Project').toString()}
+                          dataSource={this.generateProjectOptions()}
+                          style={{ width: '100%' }}
+                          showSearch
+                        />
+                      </FormItem>
+                    </Col>
+                    <Col span={7}>
+                      <FormItem required>
+                        <Select
+                          {...init(`${item.id}-role`, {
+                            rules: [{ required: true, message: 'Role is required' }],
+                          })}
+                          placeholder={i18n.t('Select Role').toString()}
+                          dataSource={this.generateProjectRoleOptions(projectValue || item.project)}
+                          style={{ width: '100%' }}
+                          disabled={!projectValue && !item.project}
+                        />
+                      </FormItem>
+                    </Col>
+                    <Col span={3}>
+                      <Button
+                        text
+                        onClick={() => this.onRemoveItem(item.id)}
+                        className="margin-top-10"
+                      >
+                        <AiOutlineDelete size={16} />
+                      </Button>
+                    </Col>
+                  </Row>
+                );
+              })}
+              <Row>
+                <Col span={24}>
+                  <Button type="secondary" onClick={this.onAddItem}>
+                    <AiOutlinePlus /> <Translation>Add Mapping</Translation>
+                  </Button>
+                </Col>
+              </Row>
+            </Form>
+          </div>
+      </div>
+    );
+  }
+}
+
+export default GroupMappings;

--- a/packages/velaux-ui/src/pages/Login/index.tsx
+++ b/packages/velaux-ui/src/pages/Login/index.tsx
@@ -134,7 +134,7 @@ export default class LoginPage extends Component<Props, State> {
     if (this.state.dexConfig) {
       const { clientID, issuer, redirectURL } = this.state.dexConfig;
       const newRedirectURl = encodeURIComponent(redirectURL);
-      const dexClientURL = `${issuer}/auth?client_id=${clientID}&redirect_uri=${newRedirectURl}&response_type=code&scope=openid+profile+email+offline_access&state=velaux`;
+      const dexClientURL = `${issuer}/auth?client_id=${clientID}&redirect_uri=${newRedirectURl}&response_type=code&scope=openid+profile+email+groups+offline_access&state=velaux`;
       window.location.href = dexClientURL;
     }
   };

--- a/packages/velaux-ui/src/pages/PlatformSetting/index.tsx
+++ b/packages/velaux-ui/src/pages/PlatformSetting/index.tsx
@@ -239,7 +239,7 @@ class PlatformSetting extends React.Component<Props, State> {
     const newRedirectURl = encodeURIComponent(redirectURL);
     return `${this.field.getValue(
       'velaAddress'
-    )}/dex/auth?client_id=${clientID}&redirect_uri=${newRedirectURl}&response_type=code&scope=openid+profile+email+offline_access&state=velaux`;
+    )}/dex/auth?client_id=${clientID}&redirect_uri=${newRedirectURl}&response_type=code&scope=openid+profile+email+groups+offline_access&state=velaux`;
   };
 
   onAddItem = () => {

--- a/packages/velaux-ui/src/services/MenuService.tsx
+++ b/packages/velaux-ui/src/services/MenuService.tsx
@@ -166,7 +166,17 @@ const defaultWorkspaceMenus: Menu[] = [
     label: 'Settings',
     name: 'settings',
     permission: { resource: 'systemSetting', action: 'update' },
-    relatedRoute: ['/settings'],
+    relatedRoute: ['^/settings$'],
+  },
+  {
+    workspace: 'admin',
+    type: MenuTypes.Workspace,
+    to: '/settings/group-mappings',
+    icon: <AiFillSetting></AiFillSetting>,
+    label: 'Group Mappings',
+    name: 'group-mappings',
+    permission: { resource: 'role:*', action: 'update' },
+    relatedRoute: ['^/settings/group-mappings$'],
   },
 ];
 

--- a/pkg/server/domain/model/group_mapping.go
+++ b/pkg/server/domain/model/group_mapping.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+// GroupRoleMapping defines the structure parsed from velaux-rbac-cm ConfigMap.
+// It maps OIDC group names to a list of project/role assignments.
+type GroupRoleMapping struct {
+	Groups map[string][]GroupProjectRole `json:"groups"`
+}
+
+// GroupProjectRole maps a group membership to a specific project and role within that project.
+type GroupProjectRole struct {
+	Project string `json:"project"`
+	Role    string `json:"role"`
+}

--- a/pkg/server/domain/service/authentication.go
+++ b/pkg/server/domain/service/authentication.go
@@ -75,11 +75,12 @@ type AuthenticationService interface {
 }
 
 type authenticationServiceImpl struct {
-	SysService     SystemInfoService   `inject:""`
-	UserService    UserService         `inject:""`
-	ProjectService ProjectService      `inject:""`
-	Store          datastore.DataStore `inject:"datastore"`
-	KubeClient     client.Client       `inject:"kubeClient"`
+	SysService          SystemInfoService   `inject:""`
+	UserService         UserService         `inject:""`
+	ProjectService      ProjectService      `inject:""`
+	GroupMappingService GroupMappingService `inject:""`
+	Store               datastore.DataStore `inject:"datastore"`
+	KubeClient          client.Client       `inject:"kubeClient"`
 }
 
 // NewAuthenticationService new authentication service
@@ -92,10 +93,11 @@ type authHandler interface {
 }
 
 type dexHandlerImpl struct {
-	idToken           *oidc.IDToken
-	Store             datastore.DataStore
-	projectService    ProjectService
-	systemInfoService SystemInfoService
+	idToken             *oidc.IDToken
+	Store               datastore.DataStore
+	projectService      ProjectService
+	systemInfoService   SystemInfoService
+	groupMappingService GroupMappingService
 }
 
 type localHandlerImpl struct {
@@ -134,10 +136,11 @@ func (a *authenticationServiceImpl) newDexHandler(ctx context.Context, req apisv
 		return nil, err
 	}
 	return &dexHandlerImpl{
-		idToken:           idToken,
-		Store:             a.Store,
-		projectService:    a.ProjectService,
-		systemInfoService: a.SysService,
+		idToken:             idToken,
+		Store:               a.Store,
+		projectService:      a.ProjectService,
+		systemInfoService:   a.SysService,
+		groupMappingService: a.GroupMappingService,
 	}, nil
 }
 
@@ -466,6 +469,8 @@ func (d *dexHandlerImpl) login(ctx context.Context) (*apisv1.UserBase, error) {
 		Name string `json:"name"`
 		// Subject - Identifier for the End-User at the Issuer.
 		Sub string `json:"sub"`
+		// Groups are the OIDC groups the user belongs to, typically provided by Dex.
+		Groups []string `json:"groups"`
 	}
 	if err := d.idToken.Claims(&claims); err != nil {
 		return nil, err
@@ -527,6 +532,14 @@ func (d *dexHandlerImpl) login(ctx context.Context) (*apisv1.UserBase, error) {
 			}
 		}
 		userBase = convertUserBase(user)
+	}
+
+	// Sync group-based project/role mappings from the velaux-rbac-cm ConfigMap
+	if d.groupMappingService != nil && len(claims.Groups) > 0 {
+		if err := d.groupMappingService.SyncUserGroupMappings(ctx, userBase.Name, claims.Groups); err != nil {
+			klog.Errorf("failed to sync group mappings for user %s: %s", userBase.Name, err.Error())
+			// Don't fail login on group mapping sync errors
+		}
 	}
 
 	return userBase, nil

--- a/pkg/server/domain/service/group_mapping.go
+++ b/pkg/server/domain/service/group_mapping.go
@@ -1,0 +1,382 @@
+/*
+Copyright 2024 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	velatypes "github.com/oam-dev/kubevela/apis/types"
+
+	"github.com/kubevela/velaux/pkg/server/domain/model"
+	"github.com/kubevela/velaux/pkg/server/infrastructure/datastore"
+	apisv1 "github.com/kubevela/velaux/pkg/server/interfaces/api/dto/v1"
+	"github.com/kubevela/velaux/pkg/server/utils/bcode"
+)
+
+const (
+	// GroupMappingConfigMapName is the name of the ConfigMap that stores group-to-project/role mappings
+	GroupMappingConfigMapName = "velaux-rbac-cm"
+	// GroupMappingConfigMapKey is the data key within the ConfigMap
+	GroupMappingConfigMapKey = "groups"
+)
+
+// GroupMappingService manages OIDC group-to-project/role mappings via a Kubernetes ConfigMap.
+type GroupMappingService interface {
+	// GetGroupMappings retrieves the current group mapping configuration from the ConfigMap.
+	GetGroupMappings(ctx context.Context) (*apisv1.GroupMappingResponse, error)
+	// UpdateGroupMappings writes the group mapping configuration to the ConfigMap.
+	UpdateGroupMappings(ctx context.Context, req apisv1.UpdateGroupMappingRequest) (*apisv1.GroupMappingResponse, error)
+	// SyncUserGroupMappings applies the group mappings for a user based on their OIDC groups.
+	// It ensures the user has the correct ProjectUser records with the correct roles.
+	SyncUserGroupMappings(ctx context.Context, userName string, oidcGroups []string) error
+	// Init ensures the velaux-rbac-cm ConfigMap exists.
+	Init(ctx context.Context) error
+}
+
+type groupMappingServiceImpl struct {
+	Store      datastore.DataStore `inject:"datastore"`
+	KubeClient client.Client       `inject:"kubeClient"`
+}
+
+// NewGroupMappingService creates a new GroupMappingService instance.
+func NewGroupMappingService() GroupMappingService {
+	return &groupMappingServiceImpl{}
+}
+
+func (g *groupMappingServiceImpl) Init(ctx context.Context) error {
+	cm := &corev1.ConfigMap{}
+	if err := g.KubeClient.Get(ctx, types.NamespacedName{
+		Name:      GroupMappingConfigMapName,
+		Namespace: velatypes.DefaultKubeVelaNS,
+	}, cm); err != nil {
+		if kerrors.IsNotFound(err) {
+			// Create the ConfigMap with empty data
+			cm = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      GroupMappingConfigMapName,
+					Namespace: velatypes.DefaultKubeVelaNS,
+				},
+				Data: map[string]string{
+					GroupMappingConfigMapKey: "{}",
+				},
+			}
+			if err := g.KubeClient.Create(ctx, cm); err != nil {
+				if !kerrors.IsAlreadyExists(err) {
+					return err
+				}
+			}
+			klog.Info("Created velaux-rbac-cm ConfigMap with empty group mappings")
+			return nil
+		}
+		return err
+	}
+	klog.Info("velaux-rbac-cm ConfigMap already exists")
+	return nil
+}
+
+func (g *groupMappingServiceImpl) GetGroupMappings(ctx context.Context) (*apisv1.GroupMappingResponse, error) {
+	mapping, err := g.readConfigMap(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return convertMappingToResponse(mapping), nil
+}
+
+func (g *groupMappingServiceImpl) UpdateGroupMappings(ctx context.Context, req apisv1.UpdateGroupMappingRequest) (*apisv1.GroupMappingResponse, error) {
+	// Validate that all referenced projects and roles exist
+	if err := g.validateMappings(ctx, req.Groups); err != nil {
+		return nil, err
+	}
+
+	// Build the model
+	mapping := &model.GroupRoleMapping{
+		Groups: make(map[string][]model.GroupProjectRole),
+	}
+	for group, roles := range req.Groups {
+		for _, r := range roles {
+			mapping.Groups[group] = append(mapping.Groups[group], model.GroupProjectRole{
+				Project: r.Project,
+				Role:    r.Role,
+			})
+		}
+	}
+
+	// Marshal to YAML
+	data, err := yaml.Marshal(mapping)
+	if err != nil {
+		return nil, bcode.ErrGroupMappingInvalidConfig
+	}
+
+	// Get or create the ConfigMap
+	cm := &corev1.ConfigMap{}
+	if err := g.KubeClient.Get(ctx, types.NamespacedName{
+		Name:      GroupMappingConfigMapName,
+		Namespace: velatypes.DefaultKubeVelaNS,
+	}, cm); err != nil {
+		if kerrors.IsNotFound(err) {
+			cm = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      GroupMappingConfigMapName,
+					Namespace: velatypes.DefaultKubeVelaNS,
+				},
+				Data: map[string]string{
+					GroupMappingConfigMapKey: string(data),
+				},
+			}
+			if err := g.KubeClient.Create(ctx, cm); err != nil {
+				return nil, err
+			}
+			return convertMappingToResponse(mapping), nil
+		}
+		return nil, err
+	}
+
+	// Update existing ConfigMap
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data[GroupMappingConfigMapKey] = string(data)
+	if err := g.KubeClient.Update(ctx, cm); err != nil {
+		return nil, err
+	}
+
+	return convertMappingToResponse(mapping), nil
+}
+
+func (g *groupMappingServiceImpl) SyncUserGroupMappings(ctx context.Context, userName string, oidcGroups []string) error {
+	if len(oidcGroups) == 0 {
+		return nil
+	}
+
+	mapping, err := g.readConfigMap(ctx)
+	if err != nil {
+		// If the ConfigMap doesn't exist, just skip silently
+		if errors.Is(err, bcode.ErrGroupMappingConfigNotFound) {
+			klog.V(4).Info("velaux-rbac-cm ConfigMap not found, skipping group mapping sync")
+			return nil
+		}
+		return err
+	}
+
+	if len(mapping.Groups) == 0 {
+		return nil
+	}
+
+	// Collect all project/role assignments from matching groups
+	type projectRole struct {
+		project string
+		role    string
+	}
+	// Use a map to deduplicate
+	assignmentSet := make(map[string]map[string]bool) // project -> set of roles
+	for _, group := range oidcGroups {
+		if roles, ok := mapping.Groups[group]; ok {
+			for _, pr := range roles {
+				if assignmentSet[pr.Project] == nil {
+					assignmentSet[pr.Project] = make(map[string]bool)
+				}
+				assignmentSet[pr.Project][pr.Role] = true
+			}
+		}
+	}
+
+	if len(assignmentSet) == 0 {
+		return nil
+	}
+
+	// For each project, create or update the ProjectUser record
+	for projectName, roles := range assignmentSet {
+		// Verify the project exists
+		project := &model.Project{Name: projectName}
+		if err := g.Store.Get(ctx, project); err != nil {
+			if errors.Is(err, datastore.ErrRecordNotExist) {
+				klog.Warningf("group mapping references non-existent project %q, skipping", projectName)
+				continue
+			}
+			return err
+		}
+
+		// Build the list of roles
+		var roleList []string
+		for role := range roles {
+			roleList = append(roleList, role)
+		}
+
+		// Try to get existing ProjectUser
+		projectUser := &model.ProjectUser{
+			Username:    userName,
+			ProjectName: projectName,
+		}
+		if err := g.Store.Get(ctx, projectUser); err != nil {
+			if errors.Is(err, datastore.ErrRecordNotExist) {
+				// Create new ProjectUser
+				projectUser.UserRoles = roleList
+				if err := g.Store.Add(ctx, projectUser); err != nil {
+					if errors.Is(err, datastore.ErrRecordExist) {
+						// Race condition - try update instead
+						projectUser.UserRoles = roleList
+						if err := g.Store.Put(ctx, projectUser); err != nil {
+							klog.Errorf("failed to update project user %s in project %s: %s", userName, projectName, err.Error())
+							continue
+						}
+					} else {
+						klog.Errorf("failed to create project user %s in project %s: %s", userName, projectName, err.Error())
+						continue
+					}
+				}
+				klog.Infof("created project user %s in project %s with roles %v via group mapping", userName, projectName, roleList)
+			} else {
+				return err
+			}
+		} else {
+			// Update existing ProjectUser roles - merge group-managed roles with existing manual roles
+			mergedRoles := mergeRoles(projectUser.UserRoles, roleList)
+			if !rolesEqual(projectUser.UserRoles, mergedRoles) {
+				projectUser.UserRoles = mergedRoles
+				if err := g.Store.Put(ctx, projectUser); err != nil {
+					klog.Errorf("failed to update project user %s in project %s: %s", userName, projectName, err.Error())
+					continue
+				}
+				klog.Infof("updated project user %s in project %s with merged roles %v via group mapping", userName, projectName, mergedRoles)
+			}
+		}
+	}
+
+	return nil
+}
+
+// readConfigMap reads and parses the velaux-rbac-cm ConfigMap.
+func (g *groupMappingServiceImpl) readConfigMap(ctx context.Context) (*model.GroupRoleMapping, error) {
+	cm := &corev1.ConfigMap{}
+	if err := g.KubeClient.Get(ctx, types.NamespacedName{
+		Name:      GroupMappingConfigMapName,
+		Namespace: velatypes.DefaultKubeVelaNS,
+	}, cm); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil, bcode.ErrGroupMappingConfigNotFound
+		}
+		return nil, err
+	}
+
+	mapping := &model.GroupRoleMapping{
+		Groups: make(map[string][]model.GroupProjectRole),
+	}
+
+	if cm.Data == nil || cm.Data[GroupMappingConfigMapKey] == "" {
+		return mapping, nil
+	}
+
+	if err := yaml.Unmarshal([]byte(cm.Data[GroupMappingConfigMapKey]), mapping); err != nil {
+		klog.Errorf("failed to parse velaux-rbac-cm ConfigMap: %s", err.Error())
+		return nil, bcode.ErrGroupMappingInvalidConfig
+	}
+
+	if mapping.Groups == nil {
+		mapping.Groups = make(map[string][]model.GroupProjectRole)
+	}
+
+	return mapping, nil
+}
+
+// validateMappings checks that all referenced projects and roles exist.
+func (g *groupMappingServiceImpl) validateMappings(ctx context.Context, groups map[string][]apisv1.GroupProjectRoleBase) error {
+	for groupName, roles := range groups {
+		for _, pr := range roles {
+			// Validate project exists
+			project := &model.Project{Name: pr.Project}
+			if err := g.Store.Get(ctx, project); err != nil {
+				if errors.Is(err, datastore.ErrRecordNotExist) {
+					klog.Errorf("group %q references non-existent project %q", groupName, pr.Project)
+					return bcode.ErrGroupMappingProjectNotExist
+				}
+				return err
+			}
+
+			// Validate role exists in the project
+			role := &model.Role{
+				Name:    pr.Role,
+				Project: pr.Project,
+			}
+			if err := g.Store.Get(ctx, role); err != nil {
+				if errors.Is(err, datastore.ErrRecordNotExist) {
+					klog.Errorf("group %q references non-existent role %q in project %q", groupName, pr.Role, pr.Project)
+					return bcode.ErrGroupMappingRoleNotExist
+				}
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// convertMappingToResponse converts the internal model to the API response DTO.
+func convertMappingToResponse(mapping *model.GroupRoleMapping) *apisv1.GroupMappingResponse {
+	resp := &apisv1.GroupMappingResponse{
+		Groups: make(map[string][]apisv1.GroupProjectRoleBase),
+	}
+	for group, roles := range mapping.Groups {
+		for _, r := range roles {
+			resp.Groups[group] = append(resp.Groups[group], apisv1.GroupProjectRoleBase{
+				Project: r.Project,
+				Role:    r.Role,
+			})
+		}
+	}
+	return resp
+}
+
+// mergeRoles merges existing roles with new group-managed roles, deduplicating.
+func mergeRoles(existing, newRoles []string) []string {
+	roleSet := make(map[string]bool)
+	for _, r := range existing {
+		roleSet[r] = true
+	}
+	for _, r := range newRoles {
+		roleSet[r] = true
+	}
+	var result []string
+	for r := range roleSet {
+		result = append(result, r)
+	}
+	return result
+}
+
+// rolesEqual checks if two role slices contain the same roles (order-independent).
+func rolesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[string]bool)
+	for _, r := range a {
+		set[r] = true
+	}
+	for _, r := range b {
+		if !set[r] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/server/domain/service/service.go
+++ b/pkg/server/domain/service/service.go
@@ -50,11 +50,12 @@ func InitServiceBean(c config.Config) []interface{} {
 	contextService := NewContextService()
 	pluginService := NewPluginService(c.PluginConfig)
 	velaQLService := NewVelaQLService()
-	needInitData = []DataInit{pluginService, clusterService, rbacService, targetService, systemInfoService, addonService}
+	groupMappingService := NewGroupMappingService()
+	needInitData = []DataInit{pluginService, clusterService, rbacService, targetService, systemInfoService, addonService, groupMappingService}
 	return []interface{}{
 		clusterService, rbacService, projectService, envService, targetService, workflowService, oamApplicationService, definitionService, addonService, envBindingService, systemInfoService, helmService, userService,
 		authenticationService, configService, applicationService, webhookService, pipelineService, pipelineRunService,
-		contextService, NewImageService(), NewCloudShellService(), pluginService, velaQLService,
+		contextService, NewImageService(), NewCloudShellService(), pluginService, velaQLService, groupMappingService,
 	}
 }
 

--- a/pkg/server/interfaces/api/dto/v1/types.go
+++ b/pkg/server/interfaces/api/dto/v1/types.go
@@ -1939,3 +1939,19 @@ type InstallPluginRequest struct {
 	Disable bool                   `json:"disable,omitempty"`
 	Options *velacommon.HTTPOption `json:"options,omitempty"`
 }
+
+// GroupMappingResponse is the response body for group mapping configuration
+type GroupMappingResponse struct {
+	Groups map[string][]GroupProjectRoleBase `json:"groups"`
+}
+
+// GroupProjectRoleBase represents a single mapping of a group to a project and role
+type GroupProjectRoleBase struct {
+	Project string `json:"project"`
+	Role    string `json:"role"`
+}
+
+// UpdateGroupMappingRequest is the request body for updating group mappings
+type UpdateGroupMappingRequest struct {
+	Groups map[string][]GroupProjectRoleBase `json:"groups"`
+}

--- a/pkg/server/interfaces/api/group_mapping.go
+++ b/pkg/server/interfaces/api/group_mapping.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	restfulspec "github.com/emicklei/go-restful-openapi/v2"
+	"github.com/emicklei/go-restful/v3"
+	"k8s.io/klog/v2"
+
+	"github.com/kubevela/velaux/pkg/server/domain/service"
+	apis "github.com/kubevela/velaux/pkg/server/interfaces/api/dto/v1"
+	"github.com/kubevela/velaux/pkg/server/utils/bcode"
+)
+
+type groupMapping struct {
+	GroupMappingService service.GroupMappingService `inject:""`
+	RbacService         service.RBACService         `inject:""`
+}
+
+// NewGroupMapping creates the group mapping API handler
+func NewGroupMapping() Interface {
+	return &groupMapping{}
+}
+
+func (g *groupMapping) GetWebServiceRoute() *restful.WebService {
+	ws := new(restful.WebService)
+	ws.Path(versionPrefix+"/group_mappings").
+		Consumes(restful.MIME_XML, restful.MIME_JSON).
+		Produces(restful.MIME_JSON, restful.MIME_XML).
+		Doc("api for OIDC group-to-project/role mappings")
+
+	tags := []string{"group_mapping"}
+
+	ws.Route(ws.GET("/").To(g.getGroupMappings).
+		Doc("get the OIDC group-to-project/role mapping configuration").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Filter(g.RbacService.CheckPerm("role", "list")).
+		Returns(200, "OK", apis.GroupMappingResponse{}).
+		Writes(apis.GroupMappingResponse{}))
+
+	ws.Route(ws.PUT("/").To(g.updateGroupMappings).
+		Doc("update the OIDC group-to-project/role mapping configuration").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Filter(g.RbacService.CheckPerm("role", "update")).
+		Reads(apis.UpdateGroupMappingRequest{}).
+		Returns(200, "OK", apis.GroupMappingResponse{}).
+		Writes(apis.GroupMappingResponse{}))
+
+	ws.Filter(authCheckFilter)
+	return ws
+}
+
+func (g *groupMapping) getGroupMappings(req *restful.Request, res *restful.Response) {
+	mappings, err := g.GroupMappingService.GetGroupMappings(req.Request.Context())
+	if err != nil {
+		klog.Errorf("failed to get group mappings: %s", err.Error())
+		bcode.ReturnError(req, res, err)
+		return
+	}
+	if err := res.WriteEntity(mappings); err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+}
+
+func (g *groupMapping) updateGroupMappings(req *restful.Request, res *restful.Response) {
+	var updateReq apis.UpdateGroupMappingRequest
+	if err := req.ReadEntity(&updateReq); err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+	mappings, err := g.GroupMappingService.UpdateGroupMappings(req.Request.Context(), updateReq)
+	if err != nil {
+		klog.Errorf("failed to update group mappings: %s", err.Error())
+		bcode.ReturnError(req, res, err)
+		return
+	}
+	if err := res.WriteEntity(mappings); err != nil {
+		bcode.ReturnError(req, res, err)
+		return
+	}
+}

--- a/pkg/server/interfaces/api/interfaces.go
+++ b/pkg/server/interfaces/api/interfaces.go
@@ -99,6 +99,7 @@ func InitAPIBean() []interface{} {
 
 	// RBAC
 	RegisterAPI(NewRBAC())
+	RegisterAPI(NewGroupMapping())
 	var beans []interface{}
 	for i := range registeredAPI {
 		beans = append(beans, registeredAPI[i])

--- a/pkg/server/utils/bcode/019_group_mapping.go
+++ b/pkg/server/utils/bcode/019_group_mapping.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2024 The KubeVela Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bcode
+
+var (
+	// ErrGroupMappingConfigNotFound means the velaux-rbac-cm ConfigMap was not found
+	ErrGroupMappingConfigNotFound = NewBcode(404, 19001, "group mapping config not found")
+	// ErrGroupMappingInvalidConfig means the group mapping configuration is invalid
+	ErrGroupMappingInvalidConfig = NewBcode(400, 19002, "invalid group mapping configuration")
+	// ErrGroupMappingProjectNotExist means a project referenced in group mapping does not exist
+	ErrGroupMappingProjectNotExist = NewBcode(400, 19003, "project in group mapping does not exist")
+	// ErrGroupMappingRoleNotExist means a role referenced in group mapping does not exist
+	ErrGroupMappingRoleNotExist = NewBcode(400, 19004, "role in group mapping does not exist")
+)


### PR DESCRIPTION
Fixes #933

### Description
This PR introduces the ability to dynamically map OIDC group claims to VelaUX Project Roles during the Dex authentication flow.

**Backend Changes:**
- Intercepts the `groups` claim during Dex login.
- Reconciles user access against group mappings defined in a system `ConfigMap` (`velaux-rbac-cm`).
- Includes a full suite of API endpoints (`/api/v1/group_mappings`) to manage these mappings.


**Example of how the mappings are stored in the ConfigMap:**
```sh
apiVersion: v1
kind: ConfigMap
metadata:
  name: velaux-rbac-cm
  namespace: vela-system
data:
  groups: |
    groups:
      platform:
      - project: platform
        role: app-developer
      rcm:
      - project: rcm
        role: app-developer
```

**Frontend Changes:**
- Appended `+groups` to the OAuth `response_type` scopes during Dex redirects so group claims are issued by the IdP.
- Added a new Settings page ("Group Mappings") matching the UI design of the "Platform Roles" page to manage the `ConfigMap`.
- Updated React Router and Menu configurations to handle the new settings route seamlessly.

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### How Has This Been Tested?
- Deployed locally utilizing `LLDAP` -> `Dex` -> `VelaUX` and verified that logging in properly grants the user access to KubeVela projects based on their group.
- Verified TypeScript UI builds successfully and Go tests compile properly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/velaux/pull/934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

