### PR TITLE
Feat: add Helm chart to install VelaUX

### DIFF
--- a/charts/velaux/.helmignore
+++ b/charts/velaux/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+*.tmproj
+.vscode/
+.idea/
+*.tgz

--- a/charts/velaux/Chart.yaml
+++ b/charts/velaux/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: velaux
+description: A Helm chart for VelaUX, the KubeVela User Experience (UX) dashboard and APIServer
+type: application
+
+# version is the chart version, bump on every chart change.
+version: 0.1.0
+
+# appVersion tracks the VelaUX application version. Used as the default image tag.
+appVersion: "v1.9.5"
+
+home: https://kubevela.io
+icon: https://static.kubevela.net/images/logos/KubeVela%20-03.png
+sources:
+  - https://github.com/kubevela/velaux
+keywords:
+  - kubevela
+  - velaux
+  - dashboard
+  - oam
+maintainers:
+  - name: Kubevela
+    url: https://kubevela.io

--- a/charts/velaux/README.md
+++ b/charts/velaux/README.md
@@ -1,0 +1,150 @@
+# VelaUX Helm Chart
+
+Install [VelaUX](https://kubevela.io) — the KubeVela User Experience (UX) dashboard and
+APIServer — into a Kubernetes cluster with Helm, instead of `vela addon enable velaux`.
+
+VelaUX is the same `oamdev/velaux` image the official addon deploys; this chart wraps it in
+plain Kubernetes manifests (Deployment, Service, ServiceAccount, RBAC, optional Ingress).
+
+## Prerequisites
+
+- Kubernetes >= 1.19
+- Helm 3
+- The KubeVela control plane (`vela-core`) already installed in the cluster.
+
+## Install
+
+```bash
+# Typically installed alongside vela-core in the vela-system namespace
+helm install velaux ./charts/velaux -n vela-system --create-namespace
+```
+
+### Expose via Ingress
+
+```bash
+helm install velaux ./charts/velaux -n vela-system \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set ingress.host=velaux.example.com
+```
+
+## Datastore & persistence
+
+The VelaUX server is stateless — it stores nothing on the pod's disk, so a pod crash or
+reschedule never loses data. Where the data lives depends on `datastore.type`:
+
+| Type | Storage | Survives pod crash | Survives cluster/etcd loss |
+| --- | --- | --- | --- |
+| `kubeapi` (default) | ConfigMaps in etcd | yes | no |
+| `mongodb` | external MongoDB | yes | yes |
+| `postgres` | external PostgreSQL | yes | yes |
+| `mysql` | external MySQL | yes | yes |
+
+For SQL/Mongo backends VelaUX creates its own schema on startup (`AutoMigrate` for SQL), so
+it only needs an empty database and a user that can create tables.
+
+### PostgreSQL via CloudNativePG (CNPG)
+
+Requires the [CNPG operator](https://cloudnative-pg.io) to be installed in the cluster.
+
+**Option 1 — let the chart provision the database (simplest).** Enable `datastore.cnpg`
+and the chart creates the CNPG `Cluster` for you, implies `datastore.type=postgres`, and wires
+VelaUX to the cluster's generated app Secret automatically:
+
+```bash
+helm install velaux ./charts/velaux -n vela-system \
+  --set datastore.cnpg.enabled=true \
+  --set datastore.cnpg.instances=3 \
+  --set datastore.cnpg.storage.size=5Gi
+```
+
+Or via a values file:
+
+```yaml
+# values-cnpg.yaml
+datastore:
+  cnpg:
+    enabled: true
+    instances: 3
+    database: velaux
+    owner: velaux
+    storage:
+      size: 5Gi
+      # storageClass: ""
+    # extraSpec:            # merged into the CNPG Cluster spec
+    #   backup: { ... }
+    #   resources: { ... }
+```
+```bash
+helm install velaux ./charts/velaux -n vela-system -f values-cnpg.yaml
+```
+
+**Option 2 — bring your own CNPG cluster.** Create the `Cluster` yourself and point VelaUX at
+its generated Secret (whose `uri` key is a ready-to-use connection string):
+
+```bash
+helm install velaux ./charts/velaux -n vela-system \
+  --set datastore.type=postgres \
+  --set datastore.urlExistingSecret.name=my-pg-app \
+  --set datastore.urlExistingSecret.key=uri
+```
+
+In both cases the URL is injected as the `VELAUX_DATASTORE_URL` env var and referenced by the
+server as `--datastore-url=$(VELAUX_DATASTORE_URL)`, so the password never appears in values or
+the pod spec. If your cluster enforces TLS and the connection is rejected, supply your own
+`datastore.url` ending in `?sslmode=require` instead of the secret.
+
+> Note: VelaUX may CrashLoopBackOff for the first few seconds until CNPG reports the database
+> ready — it recovers automatically once the cluster is up.
+
+### External MongoDB
+
+```bash
+helm install velaux ./charts/velaux -n vela-system \
+  --set datastore.type=mongodb \
+  --set datastore.database=kubevela \
+  --set datastore.url="mongodb://user:pass@mongo:27017"
+```
+
+## Accessing the dashboard
+
+With the default `ClusterIP` service:
+
+```bash
+kubectl port-forward -n vela-system svc/velaux 8000:8000
+# open http://127.0.0.1:8000
+```
+
+The initial admin password is printed in the server logs on first start.
+
+## Key values
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `replicaCount` | `1` | Number of server replicas. |
+| `image.repository` | `oamdev/velaux` | Image repository. |
+| `image.registry` | `""` | Optional registry/hub prefix. |
+| `image.tag` | `""` (chart appVersion) | Image tag. |
+| `datastore.type` | `kubeapi` | `kubeapi`, `mongodb`, `postgres`, or `mysql`. |
+| `datastore.database` | `""` | DB name; namespace for kubeapi type. |
+| `datastore.url` | `""` | Connection URL for external datastores (credentials inline). |
+| `datastore.urlExistingSecret.name` | `""` | Secret to read the connection URL from (e.g. CNPG app secret). |
+| `datastore.urlExistingSecret.key` | `uri` | Key in that Secret holding the URL. |
+| `datastore.cnpg.enabled` | `false` | Provision a CNPG Cluster and use it as the datastore (implies postgres). |
+| `datastore.cnpg.instances` | `3` | Number of PostgreSQL instances. |
+| `datastore.cnpg.database` / `.owner` | `velaux` | Database name and owner role. |
+| `datastore.cnpg.storage.size` | `5Gi` | Volume size per instance. |
+| `enableImpersonation` | `false` | Impersonate the login user against the K8s API. |
+| `serviceAccount.name` | `kubevela-ux` | ServiceAccount name (matches the addon). |
+| `rbac.create` | `true` | Create the cluster-admin ClusterRoleBinding. |
+| `service.type` | `ClusterIP` | `ClusterIP`, `NodePort`, or `LoadBalancer`. |
+| `service.port` | `8000` | Service port. |
+| `ingress.enabled` | `false` | Create an Ingress. |
+
+See [values.yaml](./values.yaml) for the full list.
+
+## RBAC note
+
+Like the official addon, this chart grants VelaUX `cluster-admin` via a `ClusterRoleBinding`
+(the ServiceAccount plus the `kubevela:ux` impersonation group). VelaUX needs broad access to
+manage applications across the cluster. Set `rbac.create=false` to manage permissions yourself.

--- a/charts/velaux/get_helm.sh
+++ b/charts/velaux/get_helm.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+
+# Copyright The Helm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The install script is based off of the MIT-licensed script from glide,
+# the package manager for Go: https://github.com/Masterminds/glide.sh/blob/master/get
+
+: ${BINARY_NAME:="helm"}
+: ${USE_SUDO:="true"}
+: ${DEBUG:="false"}
+: ${VERIFY_CHECKSUM:="true"}
+: ${VERIFY_SIGNATURES:="false"}
+: ${HELM_INSTALL_DIR:="/usr/local/bin"}
+: ${GPG_PUBRING:="pubring.kbx"}
+
+HAS_CURL="$(type "curl" &> /dev/null && echo true || echo false)"
+HAS_WGET="$(type "wget" &> /dev/null && echo true || echo false)"
+HAS_OPENSSL="$(type "openssl" &> /dev/null && echo true || echo false)"
+HAS_GPG="$(type "gpg" &> /dev/null && echo true || echo false)"
+HAS_GIT="$(type "git" &> /dev/null && echo true || echo false)"
+HAS_TAR="$(type "tar" &> /dev/null && echo true || echo false)"
+
+# initArch discovers the architecture for this system.
+initArch() {
+  ARCH=$(uname -m)
+  case $ARCH in
+    armv5*) ARCH="armv5";;
+    armv6*) ARCH="armv6";;
+    armv7*) ARCH="arm";;
+    aarch64) ARCH="arm64";;
+    x86) ARCH="386";;
+    x86_64) ARCH="amd64";;
+    i686) ARCH="386";;
+    i386) ARCH="386";;
+  esac
+}
+
+# initOS discovers the operating system for this system.
+initOS() {
+  OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
+
+  case "$OS" in
+    # Minimalist GNU for Windows
+    mingw*|cygwin*) OS='windows';;
+  esac
+}
+
+# runs the given command as root (detects if we are root already)
+runAsRoot() {
+  if [ $EUID -ne 0 -a "$USE_SUDO" = "true" ]; then
+    sudo "${@}"
+  else
+    "${@}"
+  fi
+}
+
+# verifySupported checks that the os/arch combination is supported for
+# binary builds, as well whether or not necessary tools are present.
+verifySupported() {
+  local supported="darwin-amd64\ndarwin-arm64\nlinux-386\nlinux-amd64\nlinux-arm\nlinux-arm64\nlinux-loong64\nlinux-ppc64le\nlinux-s390x\nlinux-riscv64\nwindows-amd64\nwindows-arm64"
+  if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
+    echo "No prebuilt binary for ${OS}-${ARCH}."
+    echo "To build from source, go to https://github.com/helm/helm"
+    exit 1
+  fi
+
+  if [ "${HAS_CURL}" != "true" ] && [ "${HAS_WGET}" != "true" ]; then
+    echo "Either curl or wget is required"
+    exit 1
+  fi
+
+  if [ "${VERIFY_CHECKSUM}" == "true" ] && [ "${HAS_OPENSSL}" != "true" ]; then
+    echo "In order to verify checksum, openssl must first be installed."
+    echo "Please install openssl or set VERIFY_CHECKSUM=false in your environment."
+    exit 1
+  fi
+
+  if [ "${VERIFY_SIGNATURES}" == "true" ]; then
+    if [ "${HAS_GPG}" != "true" ]; then
+      echo "In order to verify signatures, gpg must first be installed."
+      echo "Please install gpg or set VERIFY_SIGNATURES=false in your environment."
+      exit 1
+    fi
+    if [ "${OS}" != "linux" ]; then
+      echo "Signature verification is currently only supported on Linux."
+      echo "Please set VERIFY_SIGNATURES=false or verify the signatures manually."
+      exit 1
+    fi
+  fi
+
+  if [ "${HAS_GIT}" != "true" ]; then
+    echo "[WARNING] Could not find git. It is required for plugin installation."
+  fi
+
+  if [ "${HAS_TAR}" != "true" ]; then
+    echo "[ERROR] Could not find tar. It is required to extract the helm binary archive."
+    exit 1
+  fi
+}
+
+# checkDesiredVersion checks if the desired version is available.
+checkDesiredVersion() {
+  if [ "x$DESIRED_VERSION" == "x" ]; then
+    # Get tag from release URL
+    local latest_release_url="https://get.helm.sh/helm4-latest-version"
+    local latest_release_response=""
+    if [ "${HAS_CURL}" == "true" ]; then
+      latest_release_response=$( curl -L --silent --show-error --fail "$latest_release_url" 2>&1 || true )
+    elif [ "${HAS_WGET}" == "true" ]; then
+      latest_release_response=$( wget "$latest_release_url" -q -O - 2>&1 || true )
+    fi
+    TAG=$( echo "$latest_release_response" | grep '^v[0-9]' )
+    if [ "x$TAG" == "x" ]; then
+      printf "Could not retrieve the latest release tag information from %s: %s\n" "${latest_release_url}" "${latest_release_response}"
+      exit 1
+    fi
+  else
+    TAG=$DESIRED_VERSION
+  fi
+}
+
+# checkHelmInstalledVersion checks which version of helm is installed and
+# if it needs to be changed.
+checkHelmInstalledVersion() {
+  if [[ -f "${HELM_INSTALL_DIR}/${BINARY_NAME}" ]]; then
+    local version=$("${HELM_INSTALL_DIR}/${BINARY_NAME}" version --template="{{ .Version }}")
+    if [[ "$version" == "$TAG" ]]; then
+      echo "Helm ${version} is already ${DESIRED_VERSION:-latest}"
+      return 0
+    else
+      echo "Helm ${TAG} is available. Changing from version ${version}."
+      return 1
+    fi
+  else
+    return 1
+  fi
+}
+
+# downloadFile downloads the latest binary package and also the checksum
+# for that binary.
+downloadFile() {
+  HELM_DIST="helm-$TAG-$OS-$ARCH.tar.gz"
+  DOWNLOAD_URL="https://get.helm.sh/$HELM_DIST"
+  CHECKSUM_URL="$DOWNLOAD_URL.sha256"
+  HELM_TMP_ROOT="$(mktemp -dt helm-installer-XXXXXX)"
+  HELM_TMP_FILE="$HELM_TMP_ROOT/$HELM_DIST"
+  HELM_SUM_FILE="$HELM_TMP_ROOT/$HELM_DIST.sha256"
+  echo "Downloading $DOWNLOAD_URL"
+  if [ "${HAS_CURL}" == "true" ]; then
+    curl -SsL "$CHECKSUM_URL" -o "$HELM_SUM_FILE"
+    curl -SsL "$DOWNLOAD_URL" -o "$HELM_TMP_FILE"
+  elif [ "${HAS_WGET}" == "true" ]; then
+    wget -q -O "$HELM_SUM_FILE" "$CHECKSUM_URL"
+    wget -q -O "$HELM_TMP_FILE" "$DOWNLOAD_URL"
+  fi
+}
+
+# verifyFile verifies the SHA256 checksum of the binary package
+# and the GPG signatures for both the package and checksum file
+# (depending on settings in environment).
+verifyFile() {
+  if [ "${VERIFY_CHECKSUM}" == "true" ]; then
+    verifyChecksum
+  fi
+  if [ "${VERIFY_SIGNATURES}" == "true" ]; then
+    verifySignatures
+  fi
+}
+
+# installFile installs the Helm binary.
+installFile() {
+  HELM_TMP="$HELM_TMP_ROOT/$BINARY_NAME"
+  mkdir -p "$HELM_TMP"
+  tar xf "$HELM_TMP_FILE" -C "$HELM_TMP"
+  HELM_TMP_BIN="$HELM_TMP/$OS-$ARCH/helm"
+  echo "Preparing to install $BINARY_NAME into ${HELM_INSTALL_DIR}"
+  runAsRoot cp "$HELM_TMP_BIN" "$HELM_INSTALL_DIR/$BINARY_NAME"
+  echo "$BINARY_NAME installed into $HELM_INSTALL_DIR/$BINARY_NAME"
+}
+
+# verifyChecksum verifies the SHA256 checksum of the binary package.
+verifyChecksum() {
+  printf "Verifying checksum... "
+  local sum=$(openssl sha1 -sha256 ${HELM_TMP_FILE} | awk '{print $2}')
+  local expected_sum=$(cat ${HELM_SUM_FILE})
+  if [ "$sum" != "$expected_sum" ]; then
+    echo "SHA sum of ${HELM_TMP_FILE} does not match. Aborting."
+    exit 1
+  fi
+  echo "Done."
+}
+
+# verifySignatures obtains the latest KEYS file from GitHub main branch
+# as well as the signature .asc files from the specific GitHub release,
+# then verifies that the release artifacts were signed by a maintainer's key.
+verifySignatures() {
+  printf "Verifying signatures... "
+  local keys_filename="KEYS"
+  local github_keys_url="https://raw.githubusercontent.com/helm/helm/main/${keys_filename}"
+  if [ "${HAS_CURL}" == "true" ]; then
+    curl -SsL "${github_keys_url}" -o "${HELM_TMP_ROOT}/${keys_filename}"
+  elif [ "${HAS_WGET}" == "true" ]; then
+    wget -q -O "${HELM_TMP_ROOT}/${keys_filename}" "${github_keys_url}"
+  fi
+  local gpg_keyring="${HELM_TMP_ROOT}/keyring.gpg"
+  local gpg_homedir="${HELM_TMP_ROOT}/gnupg"
+  mkdir -p -m 0700 "${gpg_homedir}"
+  local gpg_stderr_device="/dev/null"
+  if [ "${DEBUG}" == "true" ]; then
+    gpg_stderr_device="/dev/stderr"
+  fi
+  gpg --batch --quiet --homedir="${gpg_homedir}" --import "${HELM_TMP_ROOT}/${keys_filename}" 2> "${gpg_stderr_device}"
+  gpg --batch --no-default-keyring --keyring "${gpg_homedir}/${GPG_PUBRING}" --export > "${gpg_keyring}"
+  local github_release_url="https://github.com/helm/helm/releases/download/${TAG}"
+  if [ "${HAS_CURL}" == "true" ]; then
+    curl -SsL "${github_release_url}/helm-${TAG}-${OS}-${ARCH}.tar.gz.sha256.asc" -o "${HELM_TMP_ROOT}/helm-${TAG}-${OS}-${ARCH}.tar.gz.sha256.asc"
+    curl -SsL "${github_release_url}/helm-${TAG}-${OS}-${ARCH}.tar.gz.asc" -o "${HELM_TMP_ROOT}/helm-${TAG}-${OS}-${ARCH}.tar.gz.asc"
+  elif [ "${HAS_WGET}" == "true" ]; then
+    wget -q -O "${HELM_TMP_ROOT}/helm-${TAG}-${OS}-${ARCH}.tar.gz.sha256.asc" "${github_release_url}/helm-${TAG}-${OS}-${ARCH}.tar.gz.sha256.asc"
+    wget -q -O "${HELM_TMP_ROOT}/helm-${TAG}-${OS}-${ARCH}.tar.gz.asc" "${github_release_url}/helm-${TAG}-${OS}-${ARCH}.tar.gz.asc"
+  fi
+  local error_text="If you think this might be a potential security issue,"
+  error_text="${error_text}\nplease see here: https://github.com/helm/community/blob/master/SECURITY.md"
+  local num_goodlines_sha=$(gpg --verify --keyring="${gpg_keyring}" --status-fd=1 "${HELM_TMP_ROOT}/helm-${TAG}-${OS}-${ARCH}.tar.gz.sha256.asc" 2> "${gpg_stderr_device}" | grep -c -E '^\[GNUPG:\] (GOODSIG|VALIDSIG)')
+  if [[ ${num_goodlines_sha} -lt 2 ]]; then
+    echo "Unable to verify the signature of helm-${TAG}-${OS}-${ARCH}.tar.gz.sha256!"
+    echo -e "${error_text}"
+    exit 1
+  fi
+  local num_goodlines_tar=$(gpg --verify --keyring="${gpg_keyring}" --status-fd=1 "${HELM_TMP_ROOT}/helm-${TAG}-${OS}-${ARCH}.tar.gz.asc" 2> "${gpg_stderr_device}" | grep -c -E '^\[GNUPG:\] (GOODSIG|VALIDSIG)')
+  if [[ ${num_goodlines_tar} -lt 2 ]]; then
+    echo "Unable to verify the signature of helm-${TAG}-${OS}-${ARCH}.tar.gz!"
+    echo -e "${error_text}"
+    exit 1
+  fi
+  echo "Done."
+}
+
+# fail_trap is executed if an error occurs.
+fail_trap() {
+  result=$?
+  if [ "$result" != "0" ]; then
+    if [[ -n "$INPUT_ARGUMENTS" ]]; then
+      echo "Failed to install $BINARY_NAME with the arguments provided: $INPUT_ARGUMENTS"
+      help
+    else
+      echo "Failed to install $BINARY_NAME"
+    fi
+    echo -e "\tFor support, go to https://github.com/helm/helm."
+  fi
+  cleanup
+  exit $result
+}
+
+# testVersion tests the installed client to make sure it is working.
+testVersion() {
+  set +e
+  HELM="$(command -v $BINARY_NAME)"
+  if [ "$?" = "1" ]; then
+    echo "$BINARY_NAME not found. Is $HELM_INSTALL_DIR on your "'$PATH?'
+    exit 1
+  fi
+  set -e
+}
+
+# help provides possible cli installation arguments
+help () {
+  echo "Accepted cli arguments are:"
+  echo -e "\t[--help|-h ] ->> prints this help"
+  echo -e "\t[--version|-v <desired_version>] . When not defined it fetches the latest release tag from the Helm CDN"
+  echo -e "\te.g. --version v4.0.0 or -v canary"
+  echo -e "\t[--no-sudo]  ->> install without sudo"
+}
+
+# cleanup temporary files to avoid https://github.com/helm/helm/issues/2977
+cleanup() {
+  if [[ -d "${HELM_TMP_ROOT:-}" ]]; then
+    rm -rf "$HELM_TMP_ROOT"
+  fi
+}
+
+# Execution
+
+#Stop execution on any error
+trap "fail_trap" EXIT
+set -e
+
+# Set debug if desired
+if [ "${DEBUG}" == "true" ]; then
+  set -x
+fi
+
+# Parsing input arguments (if any)
+export INPUT_ARGUMENTS="${@}"
+set -u
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    '--version'|-v)
+       shift
+       if [[ $# -ne 0 ]]; then
+           export DESIRED_VERSION="${1}"
+           if [[ "$1" != "v"* ]]; then
+               echo "Expected version arg ('${DESIRED_VERSION}') to begin with 'v', fixing..."
+               export DESIRED_VERSION="v${1}"
+           fi
+       else
+           echo -e "Please provide the desired version. e.g. --version v4.0.0 or -v canary"
+           exit 0
+       fi
+       ;;
+    '--no-sudo')
+       USE_SUDO="false"
+       ;;
+    '--help'|-h)
+       help
+       exit 0
+       ;;
+    *) exit 1
+       ;;
+  esac
+  shift
+done
+set +u
+
+initArch
+initOS
+verifySupported
+checkDesiredVersion
+if ! checkHelmInstalledVersion; then
+  downloadFile
+  verifyFile
+  installFile
+fi
+testVersion
+cleanup

--- a/charts/velaux/templates/NOTES.txt
+++ b/charts/velaux/templates/NOTES.txt
@@ -1,0 +1,32 @@
+VelaUX has been installed as release {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
+
+Datastore: {{ .Values.datastore.type }}
+
+Access the VelaUX dashboard:
+
+{{- if .Values.ingress.enabled }}
+
+  http{{ if .Values.ingress.tls.enabled }}s{{ end }}://{{ .Values.ingress.host }}{{ .Values.ingress.path }}
+
+{{- else if eq .Values.service.type "NodePort" }}
+
+  export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "http://$NODE_IP:{{ .Values.service.nodePort }}"
+
+{{- else if eq .Values.service.type "LoadBalancer" }}
+
+  Wait for the LoadBalancer IP:
+  kubectl get svc {{ include "velaux.fullname" . }} -n {{ .Release.Namespace }} -w
+
+{{- else }}
+
+  Port-forward to reach the dashboard locally:
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "velaux.fullname" . }} 8000:{{ .Values.service.port }}
+  Then open http://127.0.0.1:8000
+
+{{- end }}
+
+The default admin credentials are printed in the server logs on first start:
+  kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "velaux.fullname" . }} | grep -i "admin"
+
+NOTE: VelaUX requires the KubeVela control plane (vela-core) to be installed in the cluster.

--- a/charts/velaux/templates/_helpers.tpl
+++ b/charts/velaux/templates/_helpers.tpl
@@ -1,0 +1,102 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "velaux.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "velaux.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name and version as used by the chart label.
+*/}}
+{{- define "velaux.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "velaux.labels" -}}
+helm.sh/chart: {{ include "velaux.chart" . }}
+{{ include "velaux.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: kubevela
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "velaux.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "velaux.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+The name of the service account to use.
+*/}}
+{{- define "velaux.serviceAccountName" -}}
+{{- default (include "velaux.fullname" .) .Values.serviceAccount.name }}
+{{- end }}
+
+{{/*
+The full image reference.
+*/}}
+{{- define "velaux.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- if .Values.image.registry -}}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Name of the CNPG Cluster provisioned by this chart.
+*/}}
+{{- define "velaux.cnpgName" -}}
+{{- default (printf "%s-pg" (include "velaux.fullname" .)) .Values.datastore.cnpg.name }}
+{{- end }}
+
+{{/*
+Effective datastore type. CNPG provisioning implies postgres.
+*/}}
+{{- define "velaux.datastoreType" -}}
+{{- if .Values.datastore.cnpg.enabled -}}postgres{{- else -}}{{ .Values.datastore.type }}{{- end -}}
+{{- end }}
+
+{{/*
+Name of the Secret holding the datastore connection URL, or empty when none is used.
+An explicit urlExistingSecret.name wins; otherwise CNPG's generated "<cluster>-app" secret.
+*/}}
+{{- define "velaux.datastoreSecretName" -}}
+{{- if .Values.datastore.urlExistingSecret.name -}}
+{{- .Values.datastore.urlExistingSecret.name -}}
+{{- else if .Values.datastore.cnpg.enabled -}}
+{{- printf "%s-app" (include "velaux.cnpgName" .) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Key within the datastore Secret that holds the URL.
+*/}}
+{{- define "velaux.datastoreSecretKey" -}}
+{{- default "uri" .Values.datastore.urlExistingSecret.key }}
+{{- end }}

--- a/charts/velaux/templates/clusterrolebinding.yaml
+++ b/charts/velaux/templates/clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create -}}
+# VelaUX manages applications across the whole cluster, so the addon binds its
+# ServiceAccount (and the "kubevela:ux" group used for impersonation) to cluster-admin.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "velaux.fullname" . }}:kubevela:ux
+  labels:
+    {{- include "velaux.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: Group
+    name: kubevela:ux
+    apiGroup: rbac.authorization.k8s.io
+  - kind: ServiceAccount
+    name: {{ include "velaux.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/velaux/templates/cnpg-cluster.yaml
+++ b/charts/velaux/templates/cnpg-cluster.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.datastore.cnpg.enabled -}}
+# Provisioned by the velaux chart. Requires the CloudNativePG operator.
+# CNPG generates Secret "{{ include "velaux.cnpgName" . }}-app" (keys: uri, username, password, ...)
+# which the VelaUX Deployment consumes as its datastore URL.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "velaux.cnpgName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "velaux.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.datastore.cnpg.instances }}
+  {{- with .Values.datastore.cnpg.imageName }}
+  imageName: {{ . }}
+  {{- end }}
+  storage:
+    size: {{ .Values.datastore.cnpg.storage.size }}
+    {{- with .Values.datastore.cnpg.storage.storageClass }}
+    storageClass: {{ . }}
+    {{- end }}
+  bootstrap:
+    initdb:
+      database: {{ .Values.datastore.cnpg.database }}
+      owner: {{ .Values.datastore.cnpg.owner }}
+  {{- with .Values.datastore.cnpg.extraSpec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/velaux/templates/deployment.yaml
+++ b/charts/velaux/templates/deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "velaux.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "velaux.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "velaux.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "velaux.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "velaux.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: velaux-server
+          image: {{ include "velaux.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- $dsType := include "velaux.datastoreType" . }}
+          {{- $dsSecret := include "velaux.datastoreSecretName" . }}
+          {{- if and (ne $dsType "kubeapi") $dsSecret }}
+          env:
+            - name: VELAUX_DATASTORE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $dsSecret }}
+                  key: {{ include "velaux.datastoreSecretKey" . }}
+          {{- end }}
+          args:
+            - "server"
+            - "--datastore-type={{ $dsType }}"
+            - "--feature-gates=EnableCacheJSFile=true"
+            {{- if .Values.datastore.database }}
+            - "--datastore-database={{ .Values.datastore.database }}"
+            {{- end }}
+            {{- if ne $dsType "kubeapi" }}
+            {{- if $dsSecret }}
+            - "--datastore-url=$(VELAUX_DATASTORE_URL)"
+            {{- else if .Values.datastore.url }}
+            - "--datastore-url={{ .Values.datastore.url }}"
+            {{- end }}
+            {{- end }}
+            {{- if .Values.enableImpersonation }}
+            - "--feature-gates=EnableImpersonation=true"
+            {{- end }}
+            {{- range .Values.extraFeatureGates }}
+            - "--feature-gates={{ . }}"
+            {{- end }}
+            {{- range .Values.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /index.html
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/velaux/templates/ingress.yaml
+++ b/charts/velaux/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "velaux.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "velaux.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "velaux.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/charts/velaux/templates/service.yaml
+++ b/charts/velaux/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "velaux.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "velaux.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "velaux.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}

--- a/charts/velaux/templates/serviceaccount.yaml
+++ b/charts/velaux/templates/serviceaccount.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "velaux.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "velaux.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "velaux.serviceAccountName" . }}-token
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "velaux.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "velaux.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}

--- a/charts/velaux/values.yaml
+++ b/charts/velaux/values.yaml
@@ -1,0 +1,144 @@
+# Default values for velaux.
+# This is a YAML-formatted file.
+
+# -- Number of VelaUX server replicas.
+replicaCount: 1
+
+image:
+  # -- Image repository. The addon uses "oamdev/velaux".
+  repository: oamdev/velaux
+  # -- Optional image registry/hub prefix, e.g. "acr.kubevela.net". Prepended to repository when set.
+  registry: ""
+  # -- Image pull policy.
+  pullPolicy: IfNotPresent
+  # -- Image tag. Defaults to the chart appVersion when empty.
+  tag: ""
+
+# -- Image pull secrets for private registries.
+imagePullSecrets: []
+# - name: my-registry-secret
+
+# -- Override the chart name.
+nameOverride: ""
+# -- Override the fully qualified app name.
+fullnameOverride: ""
+
+datastore:
+  # -- Datastore backend: "kubeapi" (default, no external DB), "mongodb", "postgres" or "mysql".
+  type: kubeapi
+  # -- Database name. For the kubeapi type this is the namespace used to store data.
+  # For mongodb it is the database name. For postgres/mysql the db name is taken from the URL.
+  database: ""
+  # -- Connection URL for external datastores (mongodb/postgres/mysql). Ignored for kubeapi.
+  # Prefer urlExistingSecret so credentials are not stored in values.
+  # postgres example: "postgres://user:pass@host:5432/dbname?sslmode=require"
+  url: ""
+  # -- Source the connection URL from an existing Secret instead of `url`.
+  # Recommended for CloudNativePG (CNPG): point at the cluster's generated app Secret,
+  # whose "uri" key already holds a ready-to-use postgresql:// connection string.
+  urlExistingSecret:
+    # -- Name of the Secret holding the connection URL. Empty disables this.
+    name: ""
+    # -- Key within the Secret that holds the URL (CNPG's app secret exposes "uri").
+    key: uri
+  # CloudNativePG (CNPG) integration: let this chart provision the PostgreSQL cluster.
+  cnpg:
+    # -- Provision a CNPG Cluster and use it as the datastore. Implies datastore.type=postgres
+    # and sources the URL from the cluster's generated "<name>-app" Secret (key "uri").
+    # Requires the CNPG operator to be installed in the cluster.
+    enabled: false
+    # -- Cluster name. Defaults to "<release>-velaux-pg". Its app Secret is "<name>-app".
+    name: ""
+    # -- Number of PostgreSQL instances (1 = no HA).
+    instances: 3
+    # -- Name of the database and owner role created via initdb bootstrap.
+    database: velaux
+    owner: velaux
+    storage:
+      # -- Volume size per instance.
+      size: 5Gi
+      # -- StorageClass name. Empty uses the cluster default.
+      storageClass: ""
+    # -- Override the PostgreSQL container image. Empty uses the CNPG operator default.
+    imageName: ""
+    # -- Extra fields merged into the CNPG Cluster spec (e.g. backup, resources, affinity).
+    extraSpec: {}
+
+# -- Enable impersonation of the login user when calling the Kubernetes API.
+enableImpersonation: false
+
+# -- Extra feature gates passed to the server, e.g. ["EnableWebhook=true"].
+# EnableCacheJSFile=true is always set by the chart.
+extraFeatureGates: []
+
+# -- Extra command-line args appended to the server container.
+extraArgs: []
+
+serviceAccount:
+  # -- Create the ServiceAccount, its token Secret, and the cluster-admin ClusterRoleBinding.
+  create: true
+  # -- Name of the ServiceAccount. The VelaUX addon uses "kubevela-ux".
+  name: kubevela-ux
+  # -- Annotations to add to the ServiceAccount.
+  annotations: {}
+
+rbac:
+  # -- Create the ClusterRoleBinding that grants VelaUX cluster-admin (as the addon does).
+  # VelaUX needs broad access to manage applications across the cluster.
+  create: true
+
+service:
+  # -- Service type: ClusterIP, NodePort or LoadBalancer.
+  type: ClusterIP
+  # -- Service port.
+  port: 8000
+  # -- Node port used when type is NodePort.
+  nodePort: 30000
+  # -- Extra annotations for the Service.
+  annotations: {}
+
+ingress:
+  # -- Enable an Ingress for VelaUX.
+  enabled: false
+  # -- IngressClass name, e.g. "nginx" or "traefik".
+  className: ""
+  # -- Extra annotations for the Ingress.
+  annotations: {}
+  # -- Hostname to expose VelaUX on.
+  host: ""
+  # -- Ingress path.
+  path: /
+  # -- Ingress path type.
+  pathType: Prefix
+  tls:
+    # -- Enable TLS on the Ingress.
+    enabled: false
+    # -- Name of the TLS Secret containing the certificate.
+    secretName: ""
+
+# -- Resource requests and limits for the server container.
+resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 256Mi
+
+# -- Pod annotations.
+podAnnotations: {}
+
+# -- Pod-level security context.
+podSecurityContext: {}
+
+# -- Container-level security context.
+securityContext: {}
+
+# -- Node selector for pod scheduling.
+nodeSelector: {}
+
+# -- Tolerations for pod scheduling.
+tolerations: []
+
+# -- Affinity rules for pod scheduling.
+affinity: {}


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open KubeVela issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This feature adds charts/velaux so VelaUX can be installed with Helm as an alternative to 'vela addon enable velaux'. Supports kubeapi (default), mongodb, postgres and mysql datastores, and can optionally provision a CloudNativePG cluster. Mirrors the addon's deployment (oamdev/velaux 'server' on port 8000, ServiceAccount kubevela-ux, cluster-admin binding).

Fixes #916 

I have:

- [x] Read and followed KubeVela's [contribution process](https://github.com/oam-dev/kubevela/blob/master/contribute/create-pull-request.md).
- [ ] [Related Docs](https://github.com/oam-dev/kubevela.io) updated properly. In a new feature or configuration option, an update to the documentation is necessary.
- [ ] Run `yarn lint` to ensure the frontend changes are ready for review.
- [ ] Run `make reviewable`to ensure the server changes are ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.
-->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/kubevela/velaux/pull/938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

